### PR TITLE
Expose and map PostgreSQL service port to public 5432 port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile-postgres
     ports:
-      - 5432
+      - "5432:5432"
     expose:
       - "5432"
   tagbase:


### PR DESCRIPTION
This pull request should open port 5432 on the `postgres` service. It can then be accessed via client tools.