### PR TITLE
ISSUE-156 Add service to notify Slack of Docker events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,12 @@ services:
     restart: unless-stopped
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
+  slack_docker:
+    image: ghcr.io/int128/slack-docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - webhook=${webhook}
   tagbase_server:
     build:
       context: ./tagbase_server


### PR DESCRIPTION
This issue was really nice to work on :)
I simply
* created a new Slack channel in Tagbase Upgrades Slack workspace
* setup [an Incoming WebHook](https://my.slack.com/services/new/incoming-webhook) on the tagbase upgrades Slack workspace and obtained the WebHook URL.
* created a `webhook` entry in `.env` and added the Webhook URL
* `build` and then `up` to create a docker composition... this immediately sent messages 

<img width="655" alt="Screen Shot 2022-12-21 at 8 57 28 AM" src="https://user-images.githubusercontent.com/1165719/208961499-6823d939-0302-4a1c-b51b-93981f1be912.png">
