### PR TITLE
ISSUE-163 Data in iccat_gbyp0001_ArgosTrans_eTUFF.txt violates foreign key constraint histogrambindata_histogrambininfo_fkey

### DIFF
--- a/services/postgres/tagbase_schema.sql
+++ b/services/postgres/tagbase_schema.sql
@@ -278,7 +278,7 @@ CREATE TABLE data_profile (
     date_time timestamp(6) with time zone NOT NULL,
     depth character varying(30) NOT NULL,
     variable_value character varying(30) DEFAULT '',
-    position_date_time timestamp(6) with time zone DEFAULT '1970-01-01 00:00:00+00'
+    position_date_time timestamp(6) with time zone
 );
 
 


### PR DESCRIPTION
Addresses #163 
There was an error in the legacy `iccat_gbyp0001_ArgosTrans_eTUFF.txt` as [explained](https://github.com/tagbase/tagbase-server/issues/163#issuecomment-1376689808) however this was rectified/corrected in the `iccat_gbyp0008_eTUFF` replacement. Essentially dummy datetime values are provided so atleast the TRIGGER logic can execute and complete successfully.