### PR TITLE
Refactoring for reducing number of queries

### DIFF
--- a/tagbase_server/tagbase_server/test/test_ingest.py
+++ b/tagbase_server/tagbase_server/test/test_ingest.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+
+import unittest
+from unittest import mock
+
+import psycopg2
+import tagbase_server.utils.processing_utils as pu
+
+
+class TestIngest(unittest.TestCase):
+    PG_VERSION = "postgres:9.5"
+    SAMPLE_METADATA_LINES = [
+        "// global attributes:",
+        "// etag device attributes:",
+        ':instrument_name = "159903_2012_117464"',
+        ':instrument_type = "s"',
+        ':manufacturer = "Wildlife"',
+        ':model = "SPOT"',
+        ':owner_contact = "a@a.org"',
+        ':person_owner = "foo bar"',
+        ':ptt = "117464"',
+    ]
+
+    fake_submission_id = 1
+    fake_submission_filename = "test_file"
+
+    @mock.patch("psycopg2.connect")
+    def test_processing_file_metadata_with_existing_attributes(self, mock_connect):
+        metadata_attribs_in_db = [[1, "instrument_name"], [2, "model"]]
+        # result of psycopg2.connect(**connection_stuff)
+        mock_con = mock_connect.return_value
+        # result of con.cursor(cursor_factory=DictCursor)
+        mock_cur = mock_con.cursor.return_value
+        # return this when calling cur.fetchall()
+        mock_cur.fetchall.return_value = metadata_attribs_in_db
+
+        conn = psycopg2.connect(
+            dbname="test",
+            user="test",
+            host="localhost",
+            port="32780",
+            password="test",
+        )
+        cur = conn.cursor()
+
+        metadata = []
+        processed_lines = pu.process_global_attributes(
+            TestIngest.SAMPLE_METADATA_LINES,
+            cur,
+            TestIngest.fake_submission_id,
+            metadata,
+            TestIngest.fake_submission_filename,
+        )
+        assert len(TestIngest.SAMPLE_METADATA_LINES), processed_lines + 1
+        assert len(metadata_attribs_in_db), len(metadata)
+        assert metadata[0][2], "159903_2012_117464"
+        assert metadata[1][2], "SPOT"
+
+    @mock.patch("psycopg2.connect")
+    def test_processing_file_metadata_without_attributes(self, mock_connect):
+        metadata_attribs_in_db = []
+        # result of psycopg2.connect(**connection_stuff)
+        mock_con = mock_connect.return_value
+        # result of con.cursor(cursor_factory=DictCursor)
+        mock_cur = mock_con.cursor.return_value
+        # return this when calling cur.fetchall()
+        mock_cur.fetchall.return_value = metadata_attribs_in_db
+
+        conn = psycopg2.connect(
+            dbname="test",
+            user="test",
+            host="localhost",
+            port="32780",
+            password="test",
+        )
+        cur = conn.cursor()
+
+        metadata = []
+        processed_lines = pu.process_global_attributes(
+            TestIngest.SAMPLE_METADATA_LINES,
+            cur,
+            TestIngest.fake_submission_id,
+            metadata,
+            TestIngest.fake_submission_filename,
+        )
+        assert len(TestIngest.SAMPLE_METADATA_LINES), processed_lines + 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tagbase_server/tagbase_server/utils/__init__.py
+++ b/tagbase_server/tagbase_server/utils/__init__.py
@@ -1,0 +1,1 @@
+from .processing_utils import *

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -16,7 +16,12 @@ logger = logging.getLogger(__name__)
 
 
 def process_all_lines_for_global_attributes(
-    global_attributes_lines, cur, submission_id, metadata, submission_filename, line_counter
+    global_attributes_lines,
+    cur,
+    submission_id,
+    metadata,
+    submission_filename,
+    line_counter,
 ):
     attrbs_map = {}
     for line in global_attributes_lines:
@@ -29,8 +34,13 @@ def process_all_lines_for_global_attributes(
         else:
             logger.warning("Metadata line %s NOT in expected format!", line)
 
-    attrbs_names = ', '.join(['\'{}\''.format(attrib_name) for attrib_name in attrbs_map.keys()])
-    attrbs_ids_query = "SELECT attribute_id, attribute_name FROM metadata_types WHERE attribute_name IN ({})".format(attrbs_names)
+    attrbs_names = ", ".join(
+        ["'{}'".format(attrib_name) for attrib_name in attrbs_map.keys()]
+    )
+    attrbs_ids_query = (
+        "SELECT attribute_id, attribute_name FROM metadata_types "
+        "WHERE attribute_name IN ({})".format(attrbs_names)
+    )
     logger.debug("Query=%s", attrbs_ids_query)
     cur.execute(attrbs_ids_query)
     rows = cur.fetchall()
@@ -49,29 +59,6 @@ def process_all_lines_for_global_attributes(
         f"Unable to locate attribute_names *{not_found_attributes}* in _metadata_types_ table."
     )
     post_msg_to_slack(msg)
-
-
-def process_line_for_global_attributes(
-    line, cur, submission_id, metadata, submission_filename, line_counter
-):
-    logger.debug("Processing global attribute: %s", line)
-    tokens = line.strip()[1:].split(" = ")
-    logger.debug("Processing token: %s", tokens)
-    cur.execute(
-        "SELECT attribute_id FROM metadata_types WHERE attribute_name = %s",
-        (tokens[0],),
-    )
-    rows = cur.fetchall()
-    if len(rows) == 0:
-        msg = (
-            f"*{submission_filename}* _line:{line_counter}_ - "
-            f"Unable to locate attribute_name *{tokens[0]}* in _metadata_types_ table."
-        )
-        post_msg(msg)
-    else:
-        str_submission_id = str(submission_id)
-        str_row = str(rows[0][0])
-        metadata.append((str_submission_id, str_row, tokens[1]))
 
 
 def post_msg_to_slack(msg):
@@ -104,19 +91,8 @@ def process_global_attributes(lines, cur, submission_id, metadata, submission_fi
         submission_id,
         metadata,
         submission_filename,
-        processed_lines
+        processed_lines,
     )
-    # for global_attribute in global_attributes:
-    #     process_line_for_global_attributes(
-    #         global_attribute,
-    #         cur,
-    #         submission_id,
-    #         metadata,
-    #         submission_filename,
-    #         processed_lines,
-    #     )
-
-    # returning -1 because lines is an 0-indexed array
     return processed_lines - 1 if processed_lines > 0 else 0
 
 

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -53,12 +53,13 @@ def process_all_lines_for_global_attributes(
         metadata.append((str_submission_id, str(attribute_id), attribute_value))
         attrbs_map.pop(attribute_name)
 
-    not_found_attributes = ", ".join(attrbs_map.keys())
-    msg = (
-        f"*{submission_filename}* _line:{line_counter}_ - "
-        f"Unable to locate attribute_names *{not_found_attributes}* in _metadata_types_ table."
-    )
-    post_msg(msg)
+    if len(attrbs_map.keys()) > 0:
+        not_found_attributes = ", ".join(attrbs_map.keys())
+        msg = (
+            f"*{submission_filename}* _line:{line_counter}_ - "
+            f"Unable to locate attribute_names *{not_found_attributes}* in _metadata_types_ table."
+        )
+        post_msg(msg)
 
 
 def process_global_attributes(lines, cur, submission_id, metadata, submission_filename):

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from datetime import datetime as dt
 from io import StringIO

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -7,16 +7,12 @@ import time
 import pandas as pd
 import psycopg2.extras
 import pytz
-from slack_sdk import WebClient
-from slack_sdk.errors import SlackApiError
 from tzlocal import get_localzone
 
 from tagbase_server.utils.db_utils import connect
+from tagbase_server.utils.slack_utils import post_msg
 
 logger = logging.getLogger(__name__)
-slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
-slack_channel = os.environ.get("SLACK_BOT_CHANNEL", "tagbase-server")
-client = WebClient(token=slack_token)
 
 
 def process_all_lines_for_global_attributes(
@@ -71,7 +67,7 @@ def process_line_for_global_attributes(
             f"*{submission_filename}* _line:{line_counter}_ - "
             f"Unable to locate attribute_name *{tokens[0]}* in _metadata_types_ table."
         )
-        post_msg_to_slack(msg)
+        post_msg(msg)
     else:
         str_submission_id = str(submission_id)
         str_row = str(rows[0][0])
@@ -229,7 +225,7 @@ def process_etuff_file(file, version=None, notes=None):
                             f"*{submission_filename}* _line:{line_counter}_ - "
                             f"No datetime... skipping line: {stripped_line}"
                         )
-                        post_msg_to_slack(msg)
+                        post_msg(msg)
                         continue
 
                     proc_obs.append(

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -58,19 +58,7 @@ def process_all_lines_for_global_attributes(
         f"*{submission_filename}* _line:{line_counter}_ - "
         f"Unable to locate attribute_names *{not_found_attributes}* in _metadata_types_ table."
     )
-    post_msg_to_slack(msg)
-
-
-def post_msg_to_slack(msg):
-    logger.warning(msg)
-    try:
-        client.chat_postMessage(
-            channel=slack_channel, text="<!channel> :warning: " + msg
-        )
-    except SlackApiError as e:
-        logger.error(e)
-    except Exception:
-        logger.exception("Something went wrong while posting to slack")
+    post_msg(msg)
 
 
 def process_global_attributes(lines, cur, submission_id, metadata, submission_filename):

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -18,3 +18,5 @@ def post_msg(msg):
         )
     except SlackApiError as e:
         logger.error(e)
+    except Exception:
+        logger.exception("Something went wrong while posting to slack")

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -1,0 +1,18 @@
+import logging
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
+slack_channel = os.environ.get("SLACK_BOT_CHANNEL", "tagbase-server")
+client = WebClient(token=slack_token)
+logger = logging.getLogger(__name__)
+
+def post_msg(msg):
+    logger.warning(msg)
+    try:
+        client.chat_postMessage(
+            channel=slack_channel, text="<!channel> :warning: " + msg
+        )
+    except SlackApiError as e:
+        logger.error(e)

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -8,6 +8,7 @@ slack_channel = os.environ.get("SLACK_BOT_CHANNEL", "tagbase-server")
 client = WebClient(token=slack_token)
 logger = logging.getLogger(__name__)
 
+
 def post_msg(msg):
     logger.warning(msg)
     try:

--- a/tagbase_server/test-requirements.txt
+++ b/tagbase_server/test-requirements.txt
@@ -2,3 +2,4 @@ pytest~=7.2.1
 pytest-cov>=2.8.1
 pytest-randomly==3.12.0
 Flask-Testing==0.8.1
+mock==5.0.1


### PR DESCRIPTION
@lewismc this is a small refactoring such that in a second stage we can reduce the number of queries when checking global variables, i..e, instead for 1 SQL query per global attribute we can try to have just a few queries instead.
Another advantage is that we can batch the slack messages related to the metadata processing.