### PR TITLE
ISSUE-202 Use dynamic metadata in pyproject.toml to deduplicate dependency definitions

### DIFF
--- a/tagbase_server/pyproject.toml
+++ b/tagbase_server/pyproject.toml
@@ -1,18 +1,7 @@
-[build-system]
-requires = [
-    "connexion[swagger-ui]==2.14.2",
-    "flask[async]==2.2.3",
-    "gunicorn==20.1.0",
-    "pandas>=1.4.2",
-    "parmap>=1.5.3",
-    "patool>=1.12",
-    "psycopg2-binary==2.9.3",
-    "python_dateutil>=2.6.0",
-    "pytz>=2021.3",
-    "pyunpack>=0.3",
-    "setuptools>=21.0.0",
-    "slack-sdk>=3.17.2",
-    "tzlocal>=4.1",
-    "werkzeug==2.2.3",
-]
-build-backend = "setuptools.build_meta"
+[project]
+name = "tagbase_server"
+dynamic = ["dependencies", "version"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+version = {attr = "setup.VERSION"}


### PR DESCRIPTION
Addresses #202 
@renato2099 this one is self explanitory. Will make merging Dependabot PR's much easier now and makes out life easier. When combined with #200 we now only maintain dependencies in `requirements.txt` and test dependencies in `test-requirements.txt`.