### PR TITLE
Compute submission_id, tag_id sequences 

### DIFF
--- a/services/postgres/tagbase_schema.sql
+++ b/services/postgres/tagbase_schema.sql
@@ -813,6 +813,7 @@ ALTER TABLE submission_submission_id_seq OWNER TO postgres;
 
 ALTER SEQUENCE submission_submission_id_seq OWNED BY submission.submission_id;
 
+SELECT setval('submission_submission_id_seq', COALESCE(max(submission_id) + 1, 1), true) FROM submission;
 
 --
 -- Name: submission_tag_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -829,6 +830,7 @@ CREATE SEQUENCE submission_tag_id_seq
 ALTER TABLE submission_tag_id_seq OWNER TO postgres;
 
 ALTER SEQUENCE submission_tag_id_seq OWNED BY submission.tag_id;
+SELECT setval('submission_tag_id_seq', COALESCE(max(tag_id) + 1, 1), true) FROM submission;
 
 --
 -- Name: observation_types variable_id; Type: DEFAULT; Schema: public; Owner: postgres


### PR DESCRIPTION
If the submission related sequences get recreated, we shouldn't need to reset `submission_tag_id_seq` and `submission_submission_id_seq` but we should take the max current values from the `submission` table.

An easy way to test this @lewismc  is to add these SQL lines and restart the service ;) we might want to give that a try