### PR TITLE
Revert "Compute submission_id, tag_id sequences "

### DIFF
--- a/services/postgres/tagbase_schema.sql
+++ b/services/postgres/tagbase_schema.sql
@@ -813,7 +813,6 @@ ALTER TABLE submission_submission_id_seq OWNER TO postgres;
 
 ALTER SEQUENCE submission_submission_id_seq OWNED BY submission.submission_id;
 
-SELECT setval('submission_submission_id_seq', COALESCE(max(submission_id) + 1, 1), true) FROM submission;
 
 --
 -- Name: submission_tag_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -830,7 +829,6 @@ CREATE SEQUENCE submission_tag_id_seq
 ALTER TABLE submission_tag_id_seq OWNER TO postgres;
 
 ALTER SEQUENCE submission_tag_id_seq OWNED BY submission.tag_id;
-SELECT setval('submission_tag_id_seq', COALESCE(max(tag_id) + 1, 1), true) FROM submission;
 
 --
 -- Name: observation_types variable_id; Type: DEFAULT; Schema: public; Owner: postgres


### PR DESCRIPTION
Reverts tagbase/tagbase-server#204

@renato2099 I ingested two files which created `tag_id`'s and `submission_id`'s for `1` and `2` respectively below.
I then performed `docker-compose down` and then `docker-compose up` to restart all services. I then ingested data file `159903_2012_117464_eTUFF.txt`. This generated a `tag_id` and `submission_id` of `34`! This needs further testing... we can simply delay until 0.10.0 release.

When executing a GET on `/tags` I am getting the following response
```
{
  "count": 3,
  "tags": [
    {
      "filename": "/usr/src/app/data/eTUFF-sailfish-117259.txt",
      "tag_id": 1
    },
    {
      "filename": "/usr/src/app/data/159924_2013_128419_eTUFF_hdr.txt",
      "tag_id": 2
    },
    {
      "filename": "/usr/src/app/data/159903_2012_117464_eTUFF.txt",
      "tag_id": 34
    }
  ]
}
```
The `submission_id` and `tag_id` for the third entry should be `3` not `34`!