### PR TITLE
Minor suggested fix for fswatch events subset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ target/
 postgres-data
 logs
 tagbase_server/tagbase_server/coverage.xml
+services/postgis/lockfile
+postgis-data
+dbbackups
+staging_data

--- a/services/fswatch/post.sh
+++ b/services/fswatch/post.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env sh
-PATH_TO_CHECK=/usr/src/app/staging_data
+PATH_TO_CHECK=/usr/src/app/staging_data/
 while true
   do
-    fswatch --one-event $PATH_TO_CHECK --event Created --event MovedTo --event IsFile | while read line
+    fswatch --one-event $PATH_TO_CHECK --event Created --event MovedTo --event IsFile --event Updated | while read line
+    #fswatch --one-event $PATH_TO_CHECK | while read line
       do
       	filename="${line##*/}"
         echo "Contents of $PATH_TO_CHECK changed; Processing: $line"


### PR DESCRIPTION
This PR is the result of us adding more event types to the fswatch command. The goal is to avoid the parent directory from being ingested by fswatch.