### PR TITLE
ISSUE-218 data_position.lon needs to be cast to integer in tagbase_materialized_views.sql

### DIFF
--- a/services/postgis/tagbase_materialized_views.sql
+++ b/services/postgis/tagbase_materialized_views.sql
@@ -14,7 +14,7 @@ AS
     variable.date_time AS measurement_date_time,
     data_position.date_time AS position_date_time,
     data_position.lat,
-    CASE WHEN data_position.lon > 180 THEN data_position.lon - 360 ELSE data_position.lon END,
+    CASE WHEN data_position.lon::INTEGER > 180 THEN data_position.lon::INTEGER - 360 ELSE data_position.lon::INTEGER END,
     data_position.lat_err,
     data_position.lon_err
    FROM ( SELECT x.variable_value,
@@ -46,7 +46,7 @@ AS
     data.date_time AS measurement_date_time,
     data_position.date_time AS position_date_time,
     data_position.lat,
-    CASE WHEN data_position.lon > 180 THEN data_position.lon - 360 ELSE data_position.lon END,
+    CASE WHEN data_position.lon::INTEGER > 180 THEN data_position.lon::INTEGER - 360 ELSE data_position.lon::INTEGER END,
     data_position.lat_err,
     data_position.lon_err
    FROM ( SELECT data_histogram_bin_info.min_value,
@@ -72,7 +72,7 @@ AS
     data.date_time AS measurement_date_time,
     data_position.date_time AS position_date_time,
     data_position.lat,
-    CASE WHEN data_position.lon > 180 THEN data_position.lon - 360 ELSE data_position.lon END,
+    CASE WHEN data_position.lon::INTEGER > 180 THEN data_position.lon::INTEGER - 360 ELSE data_position.lon::INTEGER END,
     data_position.lat_err,
     data_position.lon_err
    FROM ( SELECT data_profile.submission_id,


### PR DESCRIPTION
Addresses #218 
I observed that although all 4 materialized views (`mview_vis_data`, `mview_vis_data_histogram `, `mview_vis_data_profile ` and `mview_vis_metadata `) were created only `mview_vis_metadata` was actually populated. We need to do more testing on the generation logic.