### PR TITLE
240: Fix issue 240 avoid loading entire observation file

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -308,7 +308,7 @@ components:
       properties:
         errors:
           type: array
-          minItems: 0
+          minItems: 1
           maxItems: 100
           description: 'The array of error entries associated with the error response'
           items:

--- a/services/docker-cron/requirements.txt
+++ b/services/docker-cron/requirements.txt
@@ -1,3 +1,3 @@
 pandas>=1.4.2
 psycopg2-binary~=2.9.5
-requests~=2.28.1
+requests~=2.30.0

--- a/tagbase_server/requirements.txt
+++ b/tagbase_server/requirements.txt
@@ -1,5 +1,5 @@
 connexion[swagger-ui]==2.14.2
-flask[async]==2.2.3
+flask[async]==2.2.5
 flask-cors==3.0.10
 gunicorn==20.1.0
 pandas>=1.4.2

--- a/tagbase_server/tagbase_server/models/error_container.py
+++ b/tagbase_server/tagbase_server/models/error_container.py
@@ -68,9 +68,9 @@ class ErrorContainer(Model):
             raise ValueError(
                 "Invalid value for `errors`, number of items must be less than or equal to `100`"
             )  # noqa: E501
-        if errors is not None and len(errors) < 0:
+        if errors is not None and len(errors) < 1:
             raise ValueError(
-                "Invalid value for `errors`, number of items must be greater than or equal to `0`"
+                "Invalid value for `errors`, number of items must be greater than or equal to `1`"
             )  # noqa: E501
 
         self._errors = errors

--- a/tagbase_server/tagbase_server/openapi/openapi.yaml
+++ b/tagbase_server/tagbase_server/openapi/openapi.yaml
@@ -467,7 +467,7 @@ components:
           items:
             $ref: '#/components/schemas/Error'
           maxItems: 100
-          minItems: 0
+          minItems: 1
           title: errors
           type: array
         trace:

--- a/tagbase_server/tagbase_server/test/test_ingest.py
+++ b/tagbase_server/tagbase_server/test/test_ingest.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+import builtins
 import unittest
 from unittest import mock
 
@@ -9,19 +10,33 @@ import tagbase_server.utils.processing_utils as pu
 
 class TestIngest(unittest.TestCase):
     SAMPLE_METADATA_LINES = [
-        "// global attributes:",
-        "// etag device attributes:",
-        ':instrument_name = "159903_2012_117464"',
-        ':instrument_type = "s"',
-        ':manufacturer = "Wildlife"',
-        ':model = "SPOT"',
-        ':owner_contact = "a@a.org"',
-        ':person_owner = "foo bar"',
-        ':ptt = "117464"',
+        b"// global attributes:",
+        b"// etag device attributes:",
+        b':instrument_name = "159903_2012_117464"',
+        b':instrument_type = "s"',
+        b':manufacturer = "Wildlife"',
+        b':model = "SPOT"',
+        b':owner_contact = "a@a.org"',
+        b':person_owner = "foo bar"',
+        b':ptt = "117464"',
     ]
 
     fake_submission_id = 1
     fake_submission_filename = "test_file"
+
+    @mock.patch.object(builtins, "open", new_callable=mock.mock_open, read_data=SAMPLE_METADATA_LINES[0])
+    def test_not_finding_any_global_attributes(self, mock_open):
+        with mock_open(TestIngest.fake_submission_filename, "r") as f:
+            global_attributes, processed_lines = pu._get_global_attributes(f)
+            self.assertEquals(len(global_attributes), 0)
+            self.assertEquals(processed_lines, 0)
+
+    @mock.patch.object(builtins, "open", new_callable=mock.mock_open, read_data=SAMPLE_METADATA_LINES[2])
+    def test_finding_a_global_attributes(self, mock_open):
+        with mock_open(TestIngest.fake_submission_filename, "r") as f:
+            global_attributes, processed_lines = pu._get_global_attributes(f)
+            self.assertEquals(len(global_attributes), 1)
+            self.assertEquals(global_attributes[0], ':instrument_name = "159903_2012_117464"')
 
     @mock.patch("psycopg2.connect")
     def test_processing_file_metadata_with_existing_attributes(self, mock_connect):
@@ -43,8 +58,9 @@ class TestIngest(unittest.TestCase):
         cur = conn.cursor()
 
         metadata = []
-        processed_lines = pu.process_global_attributes(
-            TestIngest.SAMPLE_METADATA_LINES,
+        encoded_metadata_lines = [line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES]
+        processed_lines = pu.process_all_lines_for_global_attributes(
+            encoded_metadata_lines,
             cur,
             TestIngest.fake_submission_id,
             metadata,
@@ -75,8 +91,9 @@ class TestIngest(unittest.TestCase):
         cur = conn.cursor()
 
         metadata = []
-        processed_lines = pu.process_global_attributes(
-            TestIngest.SAMPLE_METADATA_LINES,
+        encoded_metadata_lines = [line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES]
+        processed_lines = pu.process_all_lines_for_global_attributes(
+            encoded_metadata_lines,
             cur,
             TestIngest.fake_submission_id,
             metadata,

--- a/tagbase_server/tagbase_server/test/test_ingest.py
+++ b/tagbase_server/tagbase_server/test/test_ingest.py
@@ -24,19 +24,31 @@ class TestIngest(unittest.TestCase):
     fake_submission_id = 1
     fake_submission_filename = "test_file"
 
-    @mock.patch.object(builtins, "open", new_callable=mock.mock_open, read_data=SAMPLE_METADATA_LINES[0])
+    @mock.patch.object(
+        builtins,
+        "open",
+        new_callable=mock.mock_open,
+        read_data=SAMPLE_METADATA_LINES[0],
+    )
     def test_not_finding_any_global_attributes(self, mock_open):
         with mock_open(TestIngest.fake_submission_filename, "r") as f:
             global_attributes, processed_lines = pu._get_global_attributes(f)
             self.assertEquals(len(global_attributes), 0)
             self.assertEquals(processed_lines, 0)
 
-    @mock.patch.object(builtins, "open", new_callable=mock.mock_open, read_data=SAMPLE_METADATA_LINES[2])
+    @mock.patch.object(
+        builtins,
+        "open",
+        new_callable=mock.mock_open,
+        read_data=SAMPLE_METADATA_LINES[2],
+    )
     def test_finding_a_global_attributes(self, mock_open):
         with mock_open(TestIngest.fake_submission_filename, "r") as f:
             global_attributes, processed_lines = pu._get_global_attributes(f)
             self.assertEquals(len(global_attributes), 1)
-            self.assertEquals(global_attributes[0], ':instrument_name = "159903_2012_117464"')
+            self.assertEquals(
+                global_attributes[0], ':instrument_name = "159903_2012_117464"'
+            )
 
     @mock.patch("psycopg2.connect")
     def test_processing_file_metadata_with_existing_attributes(self, mock_connect):
@@ -58,7 +70,9 @@ class TestIngest(unittest.TestCase):
         cur = conn.cursor()
 
         metadata = []
-        encoded_metadata_lines = [line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES]
+        encoded_metadata_lines = [
+            line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES
+        ]
         processed_lines = pu.process_all_lines_for_global_attributes(
             encoded_metadata_lines,
             cur,
@@ -91,7 +105,9 @@ class TestIngest(unittest.TestCase):
         cur = conn.cursor()
 
         metadata = []
-        encoded_metadata_lines = [line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES]
+        encoded_metadata_lines = [
+            line.decode("utf-8") for line in TestIngest.SAMPLE_METADATA_LINES
+        ]
         processed_lines = pu.process_all_lines_for_global_attributes(
             encoded_metadata_lines,
             cur,

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -20,7 +20,6 @@ def process_all_lines_for_global_attributes(
     submission_id,
     metadata,
     submission_filename,
-    line_counter,
 ):
     attrbs_map = {}
     for line in global_attributes_lines:
@@ -55,16 +54,18 @@ def process_all_lines_for_global_attributes(
     if len(attrbs_map.keys()) > 0:
         not_found_attributes = ", ".join(attrbs_map.keys())
         msg = (
-            f"*{submission_filename}* _line:{line_counter}_ - "
+            f"*{submission_filename}*\n"
             f"Unable to locate attribute_names *{not_found_attributes}* in _metadata_types_ table."
         )
         post_msg(msg)
 
 
-def process_global_attributes(lines, cur, submission_id, metadata, submission_filename):
-    processed_lines = 0
+def _get_global_attributes(file_handler):
     global_attributes = []
-    for line in lines:
+    processed_lines = 0
+
+    while line := file_handler.readline():
+        line = line.decode("UTF-8")
         processed_lines += 1
         if line.startswith("//"):
             continue
@@ -73,15 +74,8 @@ def process_global_attributes(lines, cur, submission_id, metadata, submission_fi
         else:
             break
 
-    process_all_lines_for_global_attributes(
-        global_attributes,
-        cur,
-        submission_id,
-        metadata,
-        submission_filename,
-        processed_lines,
-    )
-    return processed_lines - 1 if processed_lines > 0 else 0
+    processed_lines = processed_lines - 1 if processed_lines > 0 else 0
+    return global_attributes, processed_lines
 
 
 def get_tag_id(cur, submission_filename):
@@ -93,6 +87,41 @@ def get_tag_id(cur, submission_filename):
     result = cur.fetchone()[0]
     logger.debug("Result: %s", result)
     return result
+
+
+def insert_new_submission(cur, tag_id, submission_filename, notes, version):
+    cur.execute(
+        "INSERT INTO submission (tag_id, filename, date_time, notes, version) VALUES (%s, %s, %s, %s, %s)",
+        (
+            tag_id,
+            submission_filename,
+            dt.now(tz=pytz.utc).astimezone(get_localzone()),
+            notes,
+            version,
+        ),
+    )
+    logger.info(
+        "Successful INSERT of '%s' into 'submission' table.",
+        submission_filename,
+    )
+
+    cur.execute("SELECT currval('submission_submission_id_seq')")
+    submission_id = cur.fetchone()[0]
+    logger.debug("New submission_id=%d", submission_id)
+    return submission_id
+
+
+def insert_metadata(cur, tag_id, metadata):
+    for x in metadata:
+        a = x[0]
+        b = x[1]
+        c = x[2]
+        mog = cur.mogrify("(%s, %s, %s, %s)", (a, b, str(c), tag_id))
+        cur.execute(
+            "INSERT INTO metadata (submission_id, attribute_id, attribute_value, tag_id) VALUES "
+            + mog.decode("utf-8")
+        )
+    logger.debug("metadata: %s", metadata)
 
 
 def process_etuff_file(file, version=None, notes=None):
@@ -107,47 +136,43 @@ def process_etuff_file(file, version=None, notes=None):
     conn.autocommit = True
     with conn:
         with conn.cursor() as cur:
+            # get tag_id based on max tag_id value found in the submission table
             tag_id = get_tag_id(cur, submission_filename)
-            cur.execute(
-                "INSERT INTO submission (tag_id, filename, date_time, notes, version) VALUES (%s, %s, %s, %s, %s)",
-                (
-                    tag_id,
-                    submission_filename,
-                    dt.now(tz=pytz.utc).astimezone(get_localzone()),
-                    notes,
-                    version,
-                ),
-            )
-            logger.info(
-                "Successful INSERT of '%s' into 'submission' table.",
-                submission_filename,
-            )
 
-            cur.execute("SELECT currval('submission_submission_id_seq')")
-            submission_id = cur.fetchone()[0]
+            submission_id = insert_new_submission(
+                cur, tag_id, submission_filename, notes, version
+            )
+            logger.debug(
+                "Working with submission_id={} tag_id={}".format(submission_id, tag_id)
+            )
 
             metadata = []
             proc_obs = []
 
             s_time = time.perf_counter()
-            with open(file, "rb") as data:
-                lines = [line.decode("utf-8", "ignore") for line in data.readlines()]
-            lines_length = len(lines)
+            with open(file, mode="rb") as data:
+                line_counter = 0
+                variable_lookup = {}
 
-            line_counter = 0
-            variable_lookup = {}
+                global_attributes, metadata_lines = _get_global_attributes(data)
+                process_all_lines_for_global_attributes(
+                    global_attributes,
+                    cur,
+                    submission_id,
+                    metadata,
+                    submission_filename,
+                )
+                line_counter += metadata_lines
 
-            metadata_lines = process_global_attributes(
-                lines, cur, submission_id, metadata, submission_filename
-            )
-            line_counter += metadata_lines
+                while line := data.readline():
+                    line_counter += 1
+                    line = line.decode("UTF-8")
+                    tokens = line.split(",")
+                    tokens = [token.replace('"', "") for token in tokens]
+                    if not tokens:
+                        continue
 
-            for counter in range(metadata_lines, lines_length):
-                line = lines[line_counter]
-                line_counter += 1
-                tokens = line.split(",")
-                tokens = [token.replace('"', "") for token in tokens]
-                if tokens:
+                    # get variable
                     variable_name = tokens[3]
                     if variable_name in variable_lookup:
                         variable_id = variable_lookup[variable_name]
@@ -187,6 +212,8 @@ def process_etuff_file(file, version=None, notes=None):
                             )
                             variable_id = cur.fetchone()[0]
                         variable_lookup[variable_name] = variable_id
+
+                    # get date from token
                     date_time = None
                     if tokens[0] != '""' and tokens[0] != "":
                         if tokens[0].startswith('"'):
@@ -213,27 +240,17 @@ def process_etuff_file(file, version=None, notes=None):
                         ]
                     )
 
-            len_proc_obs = len(proc_obs)
-            e_time = time.perf_counter()
-            sub_elapsed = round(e_time - s_time, 2)
-            logger.info(
-                "Built raw 'proc_observations' data structure from %s observations in: %s second(s)",
-                len_proc_obs,
-                sub_elapsed,
-            )
-
-            for x in metadata:
-                a = x[0]
-                b = x[1]
-                c = x[2]
-                mog = cur.mogrify("(%s, %s, %s, %s)", (a, b, str(c), tag_id))
-                cur.execute(
-                    "INSERT INTO metadata (submission_id, attribute_id, attribute_value, tag_id) VALUES "
-                    + mog.decode("utf-8")
+                len_proc_obs = len(proc_obs)
+                e_time = time.perf_counter()
+                sub_elapsed = round(e_time - s_time, 2)
+                logger.info(
+                    "Built raw 'proc_observations' data structure from %s observations in: %s second(s)",
+                    len_proc_obs,
+                    sub_elapsed,
                 )
-            logger.debug("metadata: %s", metadata)
 
-            # build pandas df
+            insert_metadata(cur, tag_id, metadata)
+
             s_time = time.perf_counter()
             df = pd.DataFrame.from_records(
                 proc_obs,


### PR DESCRIPTION
This patch avoids loading the entire observations file when processing it.
[TODO] Need to find a good way to mock the unit tests