### PR TITLE
fix: clear SonarCloud security C and code smells

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# tagbase-server
+
+HTTP API and ingestion pipeline for archival tag datasets (eTUFF) into PostgreSQL.
+
+## Language
+
+**eTUFF**:
+A text (or archive-of-text) tag data file format carrying global attributes, metadata, and observations for an archival tag deployment.
+_Avoid_: etuff file (when referring to the format itself), raw tag dump
+
+**Ingest**:
+The operation that accepts an eTUFF source (network URL or uploaded body), persists it, and loads its contents into the database.
+_Avoid_: upload-only, import (when meaning the full pipeline)
+
+**Ingest file type**:
+The OpenAPI `type` parameter naming the payload format for an ingest; today only `etuff` is supported, and that is the default when omitted.
+_Avoid_: MIME type, content-type (for this parameter)
+
+**Submission**:
+A recorded attempt to ingest a specific eTUFF source for a tag/dataset, including hashes used for duplicate detection.
+_Avoid_: upload job, ingest request (when referring to the persisted row)

--- a/tagbase_server/requirements.txt
+++ b/tagbase_server/requirements.txt
@@ -7,7 +7,6 @@ parmap>=1.7.0
 patool>=1.12
 psycopg2-binary==2.9.12
 python_dateutil>=2.6.0
-pytz>=2021.3
 pyunpack>=0.3
 slack-sdk==3.43.0
 tqdm==4.69.0

--- a/tagbase_server/tagbase_server/__main__.py
+++ b/tagbase_server/tagbase_server/__main__.py
@@ -13,6 +13,21 @@ from tagbase_server import encoder
 LOGGER_NAME = "tagbase_server"
 
 
+def parse_cors_origins(env_value=None):
+    raw = (
+        env_value
+        if env_value is not None
+        else os.environ.get("TAGBASE_CORS_ORIGINS", "")
+    )
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
+def configure_cors(flask_app, cors_factory=CORS):
+    origins = parse_cors_origins()
+    if origins:
+        cors_factory(flask_app, resources={r"/*": {"origins": origins}})
+
+
 if not os.path.exists("./logs"):
     os.makedirs("./logs")
 logger = logging.getLogger(LOGGER_NAME)
@@ -51,5 +66,5 @@ app.add_api(
     pythonic_params=True,
     strict_validation=True,
 )
-# add CORS support
-CORS(app.app)
+
+configure_cors(app.app)

--- a/tagbase_server/tagbase_server/controllers/ingest_controller.py
+++ b/tagbase_server/tagbase_server/controllers/ingest_controller.py
@@ -16,6 +16,18 @@ from tagbase_server.utils.processing_utils import process_etuff_file
 
 logger = logging.getLogger(__name__)
 
+SUPPORTED_INGEST_FILE_TYPE = "etuff"
+
+
+def _resolve_ingest_file_type(type):
+    ingest_file_type = type if type is not None else SUPPORTED_INGEST_FILE_TYPE
+    if ingest_file_type != SUPPORTED_INGEST_FILE_TYPE:
+        raise ValueError(
+            f"Unsupported ingest file type '{ingest_file_type}'; "
+            f"only '{SUPPORTED_INGEST_FILE_TYPE}' is supported."
+        )
+    return ingest_file_type
+
 
 def ingest_get(file, notes=None, type=None, version=None):  # noqa: E501
     """Get network accessible file and execute ingestion
@@ -33,6 +45,8 @@ def ingest_get(file, notes=None, type=None, version=None):  # noqa: E501
 
     :rtype: Union[Ingest200, Tuple[Ingest200, int], Tuple[Ingest200, int, Dict[str, str]]
     """
+    ingest_file_type = _resolve_ingest_file_type(type)
+    logger.info("Ingest file type: %s", ingest_file_type)
     start = time.perf_counter()
     data_file = process_get_input_data(file)
     etuff_files = []
@@ -41,7 +55,7 @@ def ingest_get(file, notes=None, type=None, version=None):  # noqa: E501
     else:
         etuff_files.append(data_file)
     logger.info("eTUFF ingestion queue: %s", etuff_files)
-    result = parmap.map(
+    parmap.map(
         process_etuff_file,
         etuff_files,
         version=version,
@@ -84,6 +98,8 @@ def ingest_post(filename, body, notes=None, type=None, version=None):  # noqa: E
 
     :rtype: Union[Ingest200, Tuple[Ingest200, int], Tuple[Ingest200, int, Dict[str, str]]
     """
+    ingest_file_type = _resolve_ingest_file_type(type)
+    logger.info("Ingest file type: %s", ingest_file_type)
     start = time.perf_counter()
     data_file = process_post_input_data(filename, body)
     etuff_files = []
@@ -92,7 +108,7 @@ def ingest_post(filename, body, notes=None, type=None, version=None):  # noqa: E
     else:
         etuff_files.append(data_file)
     logger.info("eTUFF ingestion queue: %s", etuff_files)
-    result = parmap.map(
+    parmap.map(
         process_etuff_file,
         etuff_files,
         version=version,

--- a/tagbase_server/tagbase_server/models/base_model_.py
+++ b/tagbase_server/tagbase_server/models/base_model_.py
@@ -31,22 +31,18 @@ class Model(object):
         for attr in self.openapi_types:
             value = getattr(self, attr)
             if isinstance(value, list):
-                result[attr] = list(
-                    map(lambda x: x.to_dict() if hasattr(x, "to_dict") else x, value)
-                )
+                result[attr] = [
+                    x.to_dict() if hasattr(x, "to_dict") else x for x in value
+                ]
             elif hasattr(value, "to_dict"):
                 result[attr] = value.to_dict()
             elif isinstance(value, dict):
-                result[attr] = dict(
-                    map(
-                        lambda item: (
-                            (item[0], item[1].to_dict())
-                            if hasattr(item[1], "to_dict")
-                            else item
-                        ),
-                        value.items(),
+                result[attr] = {
+                    item[0]: (
+                        item[1].to_dict() if hasattr(item[1], "to_dict") else item[1]
                     )
-                )
+                    for item in value.items()
+                }
             else:
                 result[attr] = value
 
@@ -69,4 +65,4 @@ class Model(object):
 
     def __ne__(self, other):
         """Returns true if both objects are not equal"""
-        return not self == other
+        return self.__dict__ != other.__dict__

--- a/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
+++ b/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
@@ -1,0 +1,371 @@
+# coding: utf-8
+
+import os
+import tempfile
+from datetime import timezone
+from io import StringIO
+from unittest import mock
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from tagbase_server.__main__ import configure_cors, parse_cors_origins
+from tagbase_server.controllers import ingest_controller
+from tagbase_server.controllers.ingest_controller import _resolve_ingest_file_type
+from tagbase_server.models.base_model_ import Model
+from tagbase_server.models.ingest200 import Ingest200
+from tagbase_server.utils import io_utils
+from tagbase_server.utils import processing_utils as pu
+from tagbase_server.utils import slack_utils
+
+
+def test_parse_cors_origins_empty_and_list():
+    assert parse_cors_origins("") == []
+    assert parse_cors_origins("https://a.example, https://b.example") == [
+        "https://a.example",
+        "https://b.example",
+    ]
+
+
+def test_configure_cors_skips_when_unset(monkeypatch):
+    monkeypatch.delenv("TAGBASE_CORS_ORIGINS", raising=False)
+    calls = []
+
+    def fake_cors(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    configure_cors(object(), cors_factory=fake_cors)
+    assert calls == []
+
+
+def test_configure_cors_applies_allowlist(monkeypatch):
+    monkeypatch.setenv("TAGBASE_CORS_ORIGINS", "https://a.example")
+    calls = []
+
+    def fake_cors(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    flask_app = object()
+    configure_cors(flask_app, cors_factory=fake_cors)
+    assert len(calls) == 1
+    assert calls[0][0][0] is flask_app
+    assert calls[0][1]["resources"]["/*"]["origins"] == ["https://a.example"]
+
+
+def test_io_utils_uses_tempfile_dir_not_literal_tmp():
+    assert io_utils.TEMP_DIR == tempfile.gettempdir()
+    source = open(io_utils.__file__, encoding="utf-8").read()
+    assert "/tmp/" not in source
+
+
+def test_url_scheme_prefix_matches_file_and_https():
+    assert (
+        io_utils._URL_SCHEME_PREFIX.search("file:///data/a.txt").group(0) == "file://"
+    )
+    assert (
+        io_utils._URL_SCHEME_PREFIX.search("https://example.com/a.txt").group(0)
+        == "https://example.com"
+    )
+
+
+def test_process_post_input_data_writes_under_temp_dir():
+    body = b"hello-etuff"
+    path = io_utils.process_post_input_data("sonar-post.txt", body)
+    try:
+        assert path.startswith(tempfile.gettempdir())
+        assert os.path.basename(path) == "sonar-post.txt"
+        with open(path, "rb") as handle:
+            assert handle.read() == body
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def test_process_get_input_data_local_file(tmp_path):
+    local = tmp_path / "local.txt"
+    local.write_text("x", encoding="utf-8")
+    result = io_utils.process_get_input_data(f"file://{local}")
+    assert result == str(local)
+
+
+@mock.patch("tagbase_server.utils.io_utils.Archive")
+def test_unpack_compressed_binary_uses_temp_dir(mock_archive, tmp_path):
+    archive_path = tmp_path / "bundle.zip"
+    archive_path.write_bytes(b"x")
+
+    def extractall(target):
+        assert target.startswith(tempfile.gettempdir())
+        nested = os.path.join(target, "inner.txt")
+        with open(nested, "w", encoding="utf-8") as handle:
+            handle.write("etuff")
+
+    mock_archive.return_value.extractall.side_effect = extractall
+    files = io_utils.unpack_compressed_binary(str(archive_path))
+    assert len(files) == 1
+    assert files[0].endswith("inner.txt")
+
+
+@mock.patch("tagbase_server.utils.io_utils.urlopen")
+def test_process_get_input_data_downloads_remote(mock_urlopen, tmp_path):
+    mock_urlopen.return_value.read.side_effect = [b"chunk", b""]
+    path = io_utils.process_get_input_data("https://example.com/remote.txt")
+    try:
+        assert path.startswith(tempfile.gettempdir())
+        with open(path, "rb") as handle:
+            assert handle.read() == b"chunk"
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def test_resolve_ingest_file_type_defaults_and_rejects():
+    assert _resolve_ingest_file_type(None) == "etuff"
+    assert _resolve_ingest_file_type("etuff") == "etuff"
+    with pytest.raises(ValueError, match="Unsupported ingest file type"):
+        _resolve_ingest_file_type("csv")
+
+
+@mock.patch("tagbase_server.controllers.ingest_controller.parmap.map")
+@mock.patch("tagbase_server.controllers.ingest_controller.process_get_input_data")
+def test_ingest_get_happy_path(mock_get, mock_map):
+    mock_get.return_value = "/data/file.txt"
+    mock_map.return_value = [0]
+    result = ingest_controller.ingest_get("file:///data/file.txt", type="etuff")
+    assert result.code == "200"
+    mock_map.assert_called_once()
+
+
+@mock.patch("tagbase_server.controllers.ingest_controller.parmap.map")
+@mock.patch("tagbase_server.controllers.ingest_controller.unpack_compressed_binary")
+@mock.patch("tagbase_server.controllers.ingest_controller.process_post_input_data")
+def test_ingest_post_archive_path(mock_post, mock_unpack, mock_map):
+    mock_post.return_value = "/data/bundle.zip"
+    mock_unpack.return_value = ["/data/a.txt"]
+    mock_map.return_value = [0]
+    result = ingest_controller.ingest_post("bundle.zip", b"x", type=None)
+    assert result.code == "200"
+    mock_unpack.assert_called_once()
+
+
+def test_processing_utils_has_no_pytz():
+    source = open(pu.__file__, encoding="utf-8").read()
+    assert "pytz" not in source
+    assert "timezone.utc" in source
+    assert timezone.utc is not None
+
+
+def test_resolve_variable_id_cache_and_lookup():
+    cur = mock.Mock()
+    conn = mock.Mock()
+    lookup = {"temp": 9}
+    assert pu._resolve_variable_id(cur, conn, "temp", [], lookup) == 9
+
+    cur.fetchone.return_value = (42,)
+    lookup = {}
+    assert (
+        pu._resolve_variable_id(cur, conn, "lat", ["", "", "", "lat", "deg"], lookup)
+        == 42
+    )
+    assert lookup["lat"] == 42
+
+
+def test_resolve_variable_id_insert_and_exception():
+    cur = mock.Mock()
+    conn = mock.Mock()
+    cur.fetchone.side_effect = [None, (7,)]
+    cur.execute.side_effect = [None, Exception("dup"), None]
+    lookup = {}
+    assert (
+        pu._resolve_variable_id(cur, conn, "lon", ["", "", "", "lon", "deg"], lookup)
+        == 7
+    )
+    conn.rollback.assert_called_once()
+
+
+@mock.patch("tagbase_server.utils.processing_utils.post_msg")
+def test_build_proc_observations(mock_post):
+    cur = mock.Mock()
+    conn = mock.Mock()
+    cur.fetchone.return_value = (3,)
+    content = [
+        "2012-03-16 18:31:39,2,22.2,longitude,degree",
+        ",2,22.2,longitude,degree",
+    ]
+    proc_obs, count = pu._build_proc_observations(cur, conn, content, "f.txt", 1, 2)
+    assert count == 1
+    assert proc_obs[0][1] == 3
+    mock_post.assert_called_once()
+
+
+def test_dataframe_to_buffer_and_migrate():
+    proc_obs = [[timezone.utc, 1, "1.0", 2, 3]]
+    buffer = pu._dataframe_to_buffer(proc_obs, 1)
+    assert isinstance(buffer, StringIO)
+
+    cur = mock.Mock()
+    conn = mock.Mock()
+    elapsed = pu._migrate_proc_observations(cur, conn, buffer, 9, 1)
+    assert isinstance(elapsed, float)
+    cur.copy_from.assert_called_once()
+
+    cur.copy_from.side_effect = Exception("db")
+    assert pu._migrate_proc_observations(cur, conn, buffer, 9, 0) is False
+    conn.rollback.assert_called()
+
+
+@mock.patch("tagbase_server.utils.processing_utils.get_dataset_properties")
+@mock.patch("tagbase_server.utils.processing_utils.compute_file_sha256")
+@mock.patch("tagbase_server.utils.processing_utils.make_hash_sha256")
+def test_compute_submission_hashes(mock_make, mock_file, mock_props):
+    mock_props.return_value = (
+        "inst",
+        "sn",
+        "ptt",
+        "plat",
+        0,
+        ["line"],
+        [":a = 1"],
+        0,
+    )
+    mock_make.side_effect = ["content", "meta"]
+    mock_file.return_value = "filehash"
+    result = pu._compute_submission_hashes("f.txt")
+    assert result[0] == "inst"
+    assert result[-1] == "filehash"
+    assert result[-2] == "meta"
+
+
+@mock.patch("tagbase_server.utils.processing_utils._migrate_proc_observations")
+@mock.patch("tagbase_server.utils.processing_utils._dataframe_to_buffer")
+@mock.patch("tagbase_server.utils.processing_utils._build_proc_observations")
+@mock.patch("tagbase_server.utils.processing_utils.insert_metadata")
+@mock.patch("tagbase_server.utils.processing_utils.is_only_metadata_change")
+@mock.patch("tagbase_server.utils.processing_utils.process_global_attributes_metadata")
+@mock.patch("tagbase_server.utils.processing_utils.get_current_submission_id")
+@mock.patch("tagbase_server.utils.processing_utils.insert_new_submission")
+@mock.patch("tagbase_server.utils.processing_utils.get_submission_id")
+@mock.patch("tagbase_server.utils.processing_utils.get_tag_id")
+@mock.patch("tagbase_server.utils.processing_utils.get_dataset_id")
+@mock.patch("tagbase_server.utils.processing_utils.detect_duplicate_file")
+@mock.patch("tagbase_server.utils.processing_utils._compute_submission_hashes")
+@mock.patch("tagbase_server.utils.processing_utils.connect")
+def test_process_etuff_file_full_path(
+    mock_connect,
+    mock_hashes,
+    mock_dup,
+    mock_dataset,
+    mock_tag,
+    mock_sub,
+    mock_insert,
+    mock_curr,
+    mock_meta,
+    mock_meta_only,
+    mock_insert_meta,
+    mock_build,
+    mock_buffer,
+    mock_migrate,
+):
+    conn = mock.MagicMock()
+    cur = mock.MagicMock()
+    mock_connect.return_value = conn
+    conn.__enter__.return_value = conn
+    conn.cursor.return_value.__enter__.return_value = cur
+    mock_hashes.return_value = (
+        "i",
+        "s",
+        "p",
+        "pl",
+        1,
+        ["line"],
+        [":a = 1"],
+        0,
+        "ch",
+        "mh",
+        "fh",
+    )
+    mock_dup.return_value = False
+    mock_dataset.return_value = 1
+    mock_tag.return_value = 2
+    mock_sub.return_value = None
+    mock_curr.return_value = 3
+    mock_meta.return_value = [("3", "1", "v")]
+    mock_meta_only.return_value = False
+    mock_build.return_value = ([[timezone.utc, 1, "1", 3, 2]], 1)
+    mock_buffer.return_value = StringIO("x")
+    mock_migrate.return_value = 0.1
+    assert pu.process_etuff_file("f.txt") is None
+
+
+@mock.patch("tagbase_server.utils.processing_utils.connect")
+@mock.patch("tagbase_server.utils.processing_utils._compute_submission_hashes")
+def test_process_etuff_file_duplicate(mock_hashes, mock_connect):
+    conn = mock.MagicMock()
+    cur = mock.MagicMock()
+    mock_connect.return_value = conn
+    conn.__enter__.return_value = conn
+    conn.cursor.return_value.__enter__.return_value = cur
+    mock_hashes.return_value = (
+        "i",
+        "s",
+        "p",
+        "pl",
+        0,
+        [],
+        [],
+        0,
+        "c",
+        "m",
+        "f",
+    )
+    with mock.patch(
+        "tagbase_server.utils.processing_utils.detect_duplicate_file",
+        return_value=True,
+    ):
+        assert pu.process_etuff_file("f.txt") == 1
+
+
+def test_base_model_ne_and_to_dict_branches():
+    class Child(Model):
+        openapi_types = {"name": str}
+        attribute_map = {"name": "name"}
+
+        def __init__(self, name="x"):
+            self.name = name
+
+    class Parent(Model):
+        openapi_types = {"items": list, "nested": object, "mapping": dict, "plain": str}
+        attribute_map = {
+            "items": "items",
+            "nested": "nested",
+            "mapping": "mapping",
+            "plain": "plain",
+        }
+
+        def __init__(self):
+            self.items = [Child("a")]
+            self.nested = Child("b")
+            self.mapping = {"k": Child("c")}
+            self.plain = "p"
+
+    parent = Parent()
+    as_dict = parent.to_dict()
+    assert as_dict["items"][0]["name"] == "a"
+    assert as_dict["nested"]["name"] == "b"
+    assert as_dict["mapping"]["k"]["name"] == "c"
+    a = Ingest200.from_dict({"code": "200", "elapsed": 1.0, "message": "a"})
+    b = Ingest200.from_dict({"code": "200", "elapsed": 1.0, "message": "b"})
+    assert a != b
+    assert not (a != a)
+
+
+def test_slack_utils_exception_paths():
+    with mock.patch.object(
+        slack_utils.client,
+        "chat_postMessage",
+        side_effect=SlackApiError("fail", response=mock.Mock()),
+    ):
+        slack_utils.post_msg("hi")
+    with mock.patch.object(
+        slack_utils.client, "chat_postMessage", side_effect=RuntimeError("boom")
+    ):
+        slack_utils.post_msg("hi")

--- a/tagbase_server/tagbase_server/utils/io_utils.py
+++ b/tagbase_server/tagbase_server/utils/io_utils.py
@@ -9,6 +9,9 @@ from urllib.request import urlopen
 
 logger = logging.getLogger(__name__)
 
+TEMP_DIR = tempfile.gettempdir()
+_URL_SCHEME_PREFIX = re.compile(r"(?:file|ftp|https?)://[^/]*")
+
 
 def compute_file_sha256(file_name):
     """
@@ -46,7 +49,7 @@ def make_hashable(o):
 def process_get_input_data(file):
     """
     Capable of acquiring data over HTTP, HTTPS, FTP and FILE protocols.
-    Data not already on the filesystem is saved to /tmp.
+    Data not already on the filesystem is saved under the process temp directory.
     No explicit cleanup is performed per-se however details of the implementation
     can be found in https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile
     All input is expected to have utf-8 encoding.
@@ -56,37 +59,36 @@ def process_get_input_data(file):
 
     """
     data_file = file
-    local_data_file = data_file[
-        re.search(r"[file|ftp|http|https]://[^/]*", data_file).end() :
-    ]
+    match = _URL_SCHEME_PREFIX.search(data_file)
+    local_data_file = data_file[match.end() :] if match else data_file
     if os.path.isfile(local_data_file):
         data_file = local_data_file
         logger.info("Found '%s' on filesystem.", local_data_file)
     else:
         logger.info("Acquiring '%s' from remote source.", data_file)
-        filename = tempfile.TemporaryFile(
-            dir="/tmp/" + data_file[data_file.rindex("/") + 1 :],
-            encoding="utf-8",
-            mode='"w"',
-        )
-        response = urlopen(data_file)
-        chunk_size = 16 * 1024
-        with open(filename, "wb") as f:
+        basename = data_file[data_file.rindex("/") + 1 :]
+        with tempfile.NamedTemporaryFile(
+            dir=TEMP_DIR,
+            prefix=f"{basename}.",
+            delete=False,
+            mode="wb",
+        ) as tmp:
+            response = urlopen(data_file)
+            chunk_size = 16 * 1024
             while True:
                 chunk = response.read(chunk_size)
                 if not chunk:
                     break
-                f.write(chunk)
-
-        data_file = filename
+                tmp.write(chunk)
+            data_file = tmp.name
     logger.info(data_file)
     return data_file
 
 
 def process_post_input_data(filename, body):
     """
-    Writes POST data (application/octet-stream or text/plain) to /tmp
-    No explicit /tmp cleanup is performed per-se however details of the implementation
+    Writes POST data (application/octet-stream or text/plain) under the process temp directory.
+    No explicit temp cleanup is performed per-se however details of the implementation
     can be found in https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile
     All input is expected to have utf-8 encoding.
 
@@ -97,17 +99,16 @@ def process_post_input_data(filename, body):
 
     """
     data = body
-    filepath = "/tmp/" + filename
+    filepath = os.path.join(TEMP_DIR, filename)
     with open(filepath, mode="wb") as f:
         f.write(data)
-    f.close()
     logger.debug(filepath)
     return filepath
 
 
 def unpack_compressed_binary(file):
     """
-    Unpack a variety of compressed input files storing all .txt contents to /tmp.
+    Unpack a variety of compressed input files storing all .txt contents under the process temp directory.
     No explicit cleanup is performed per-se however details of the implementation
     can be found in https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile
     For a list of files which can be processed, see
@@ -118,7 +119,7 @@ def unpack_compressed_binary(file):
     :type file: str
     """
     etuff_files = []
-    temp_dir = "/tmp/" + str(time())
+    temp_dir = os.path.join(TEMP_DIR, str(time()))
     if not os.path.exists(temp_dir):
         os.mkdir(temp_dir)
     logger.info("Unpacking %s archive to %s", file, temp_dir)

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -1,11 +1,11 @@
 import logging
 from datetime import datetime as dt
+from datetime import timezone
 from io import StringIO
 import time
 
 import pandas as pd
 import psycopg2.extras
-import pytz
 from tzlocal import get_localzone
 
 from tagbase_server.utils.db_utils import connect
@@ -156,7 +156,7 @@ def insert_new_submission(
         (
             tag_id,
             submission_filename,
-            dt.now(tz=pytz.utc).astimezone(get_localzone()),
+            dt.now(tz=timezone.utc).astimezone(get_localzone()),
             notes,
             version,
             file_sha256,
@@ -311,7 +311,7 @@ def update_submission_metadata(
     cur, tag_id, metadata, submission_id, dataset_id, metadata_hash
 ):
     # update submission information
-    current_time = dt.now(tz=pytz.utc).astimezone(get_localzone())
+    current_time = dt.now(tz=timezone.utc).astimezone(get_localzone())
     cur.execute(
         "UPDATE submission SET md_sha256 = '{}', date_time = '{}'"
         " WHERE tag_id = {} AND dataset_id = {} AND submission_id = {}".format(
@@ -336,18 +336,168 @@ def update_submission_metadata(
     logger.info("Updated metadata attributes: %s", metadata)
 
 
-def process_etuff_file(file, version=None, notes=None):
-    start = time.perf_counter()
-    submission_filename = file  # full path name is now preferred rather than - file[file.rindex("/") + 1 :]
-    logger.info(
-        "Processing etuff file: %s",
-        submission_filename,
+def _resolve_variable_id(cur, conn, variable_name, tokens, variable_lookup):
+    if variable_name in variable_lookup:
+        return variable_lookup[variable_name]
+
+    cur.execute(
+        "SELECT variable_id FROM observation_types WHERE variable_name = %s",
+        (variable_name,),
+    )
+    row = cur.fetchone()
+    if row:
+        variable_id = row[0]
+    else:
+        try:
+            logger.debug(
+                "variable_name=%s\ttokens=%s",
+                variable_name,
+                tokens,
+            )
+            cur.execute(
+                "INSERT INTO observation_types("
+                "variable_name, variable_units) VALUES (%s, %s) "
+                "ON CONFLICT (variable_name) DO NOTHING",
+                (variable_name, tokens[4].strip()),
+            )
+        except (
+            Exception,
+            psycopg2.DatabaseError,
+        ):
+            logger.exception(
+                "variable_id '%s' already exists in 'observation_types'. tokens: '%s'",
+                variable_name,
+                tokens,
+            )
+            conn.rollback()
+        cur.execute("SELECT nextval('observation_types_variable_id_seq')")
+        variable_id = cur.fetchone()[0]
+    variable_lookup[variable_name] = variable_id
+    return variable_id
+
+
+def _build_proc_observations(
+    cur, conn, file_content, submission_filename, submission_id, tag_id
+):
+    proc_obs = []
+    variable_lookup = {}
+    s_time = time.perf_counter()
+    num_lines_content = len(file_content)
+    logger.debug(
+        "len number_global_atttributes_lines content lines: '%s'",
+        num_lines_content,
     )
 
-    conn = connect()
-    conn.autocommit = True
+    for counter in range(0, num_lines_content):
+        line = file_content[counter]
+        line_number = counter + 1
+        tokens = line.split(",")
+        tokens = [token.replace('"', "") for token in tokens]
+        if not tokens:
+            continue
 
-    # TODO we should read the file once and return the hashes we need (metadata/content/entire-file)
+        variable_name = tokens[3]
+        variable_id = _resolve_variable_id(
+            cur, conn, variable_name, tokens, variable_lookup
+        )
+        if tokens[0] != '""' and tokens[0] != "":
+            if tokens[0].startswith('"'):
+                tokens[0].replace('"', "")
+            date_time = dt.strptime(tokens[0], "%Y-%m-%d %H:%M:%S").astimezone(
+                timezone.utc
+            )
+        else:
+            stripped_line = line.strip("\n")
+            msg = (
+                f"*{submission_filename}* _line:{line_number}_ - "
+                f"No datetime... skipping line: {stripped_line}"
+            )
+            post_msg(msg)
+            continue
+        proc_obs.append(
+            [
+                date_time,
+                variable_id,
+                tokens[2],
+                submission_id,
+                tag_id,
+            ]
+        )
+
+    len_proc_obs = len(proc_obs)
+    e_time = time.perf_counter()
+    sub_elapsed = round(e_time - s_time, 2)
+    logger.info(
+        "Built raw 'proc_observations' data structure from %s observations in: %s second(s)",
+        len_proc_obs,
+        sub_elapsed,
+    )
+    return proc_obs, len_proc_obs
+
+
+def _dataframe_to_buffer(proc_obs, len_proc_obs):
+    s_time = time.perf_counter()
+    df = pd.DataFrame.from_records(
+        proc_obs,
+        columns=[
+            "date_time",
+            "variable_id",
+            "variable_value",
+            "submission_id",
+            "tag_id",
+        ],
+    )
+    e_time = time.perf_counter()
+    sub_elapsed = round(e_time - s_time, 2)
+    logger.info(
+        "Built Pandas DF from %s records. Time elapsed: %s second(s)",
+        len_proc_obs,
+        sub_elapsed,
+    )
+    logger.debug("DF Info: %s", df.info)
+    logger.debug("DF Memory Usage: %s", df.memory_usage(True))
+
+    s_time = time.perf_counter()
+    buffer = StringIO()
+    df.to_csv(buffer, header=False, index=False)
+    buffer.seek(0)
+    e_time = time.perf_counter()
+    sub_elapsed = round(e_time - s_time, 2)
+    logger.info(
+        "Copied Pandas DF to StringIO memory buffer. Time elapsed: %s second(s)",
+        sub_elapsed,
+    )
+    return buffer
+
+
+def _migrate_proc_observations(
+    cur, conn, buffer, submission_id, referencetrack_included
+):
+    s_time = time.perf_counter()
+    logger.info(
+        "Copying memory buffer to 'proc_observations' and executing data migration."
+    )
+    try:
+        cur.copy_from(buffer, "proc_observations", sep=",")
+        ref = bool(referencetrack_included)
+        logger.debug(
+            "Executing sp_execute_data_migration(%s, %s);",
+            int(submission_id),
+            ref,
+        )
+        cur.execute(
+            "CALL sp_execute_data_migration(%s, %s);", (int(submission_id), ref)
+        )
+    except (Exception, psycopg2.DatabaseError):
+        logger.exception("Error migrating proc_observations")
+        conn.rollback()
+        return False
+    e_time = time.perf_counter()
+    sub_elapsed = round(e_time - s_time, 2)
+    return sub_elapsed
+
+
+def _compute_submission_hashes(submission_filename):
     (
         instrument_name,
         serial_number,
@@ -364,6 +514,45 @@ def process_etuff_file(file, version=None, notes=None):
     logger.debug("MD Hash: %s", metadata_hash)
     entire_file_hash = compute_file_sha256(submission_filename)
     logger.debug("File Hash: %s", entire_file_hash)
+    return (
+        instrument_name,
+        serial_number,
+        ptt,
+        platform,
+        referencetrack_included,
+        file_content,
+        metadata_content,
+        number_global_attributes_lines,
+        content_hash,
+        metadata_hash,
+        entire_file_hash,
+    )
+
+
+def process_etuff_file(file, version=None, notes=None):
+    start = time.perf_counter()
+    submission_filename = file
+    logger.info(
+        "Processing etuff file: %s",
+        submission_filename,
+    )
+
+    conn = connect()
+    conn.autocommit = True
+
+    (
+        instrument_name,
+        serial_number,
+        ptt,
+        platform,
+        referencetrack_included,
+        file_content,
+        metadata_content,
+        number_global_attributes_lines,
+        content_hash,
+        metadata_hash,
+        entire_file_hash,
+    ) = _compute_submission_hashes(submission_filename)
 
     with conn:
         with conn.cursor() as cur:
@@ -400,7 +589,6 @@ def process_etuff_file(file, version=None, notes=None):
                 )
                 submission_id = get_current_submission_id(cur)
 
-            # compute global attributes which are considered as metadata
             metadata = process_global_attributes_metadata(
                 metadata_content,
                 cur,
@@ -415,163 +603,21 @@ def process_etuff_file(file, version=None, notes=None):
                 )
                 return 1
 
-            proc_obs = []
-            variable_lookup = {}
-            # at this point we have already read form the file all global attribute lines
-            # line_counter = number_global_attributes_lines
-
-            # # TODO we should use the 'content' variable in the following
-            s_time = time.perf_counter()
-            # with open(file, "rb") as data:
-            #     lines = [line.decode("utf-8", "ignore") for line in data.readlines()]
-            # lines_length = len(lines)
-
-            num_lines_content = len(file_content)
-            logger.debug(
-                "len number_global_atttributes_lines: '%s' len lines_length: '%s'",
-                number_global_attributes_lines,
-                num_lines_content,
+            proc_obs, len_proc_obs = _build_proc_observations(
+                cur,
+                conn,
+                file_content,
+                submission_filename,
+                submission_id,
+                tag_id,
             )
-
-            for counter in range(0, num_lines_content):
-                line = file_content[counter]
-                counter += 1
-                tokens = line.split(",")
-                tokens = [token.replace('"', "") for token in tokens]
-                if tokens:
-                    variable_name = tokens[3]
-                    if variable_name in variable_lookup:
-                        variable_id = variable_lookup[variable_name]
-                    else:
-                        cur.execute(
-                            "SELECT variable_id FROM observation_types WHERE variable_name = %s",
-                            (variable_name,),
-                        )
-                        row = cur.fetchone()
-                        if row:
-                            variable_id = row[0]
-                        else:
-                            try:
-                                logger.debug(
-                                    "variable_name=%s\ttokens=%s",
-                                    variable_name,
-                                    tokens,
-                                )
-                                cur.execute(
-                                    "INSERT INTO observation_types("
-                                    "variable_name, variable_units) VALUES (%s, %s) "
-                                    "ON CONFLICT (variable_name) DO NOTHING",
-                                    (variable_name, tokens[4].strip()),
-                                )
-                            except (
-                                Exception,
-                                psycopg2.DatabaseError,
-                            ) as error:
-                                logger.error(
-                                    "variable_id '%s' already exists in 'observation_types'. tokens:"
-                                    " '%s. \nerror: %s",
-                                    variable_name,
-                                    tokens,
-                                    error,
-                                )
-                                conn.rollback()
-                            cur.execute(
-                                "SELECT nextval('observation_types_variable_id_seq')"
-                            )
-                            variable_id = cur.fetchone()[0]
-                        variable_lookup[variable_name] = variable_id
-                    date_time = None
-                    if tokens[0] != '""' and tokens[0] != "":
-                        if tokens[0].startswith('"'):
-                            tokens[0].replace('"', "")
-                        date_time = dt.strptime(
-                            tokens[0], "%Y-%m-%d %H:%M:%S"
-                        ).astimezone(pytz.utc)
-                    else:
-                        stripped_line = line.strip("\n")
-                        msg = (
-                            f"*{submission_filename}* _line:{counter}_ - "
-                            f"No datetime... skipping line: {stripped_line}"
-                        )
-                        post_msg(msg)
-                        continue
-                    proc_obs.append(
-                        [
-                            date_time,
-                            variable_id,
-                            tokens[2],
-                            submission_id,
-                            tag_id,
-                        ]
-                    )
-
-            len_proc_obs = len(proc_obs)
-            e_time = time.perf_counter()
-            sub_elapsed = round(e_time - s_time, 2)
-            logger.info(
-                "Built raw 'proc_observations' data structure from %s observations in: %s second(s)",
-                len_proc_obs,
-                sub_elapsed,
-            )
-
             insert_metadata(cur, metadata, tag_id)
-
-            # build pandas df
-            s_time = time.perf_counter()
-            df = pd.DataFrame.from_records(
-                proc_obs,
-                columns=[
-                    "date_time",
-                    "variable_id",
-                    "variable_value",
-                    "submission_id",
-                    "tag_id",
-                ],
+            buffer = _dataframe_to_buffer(proc_obs, len_proc_obs)
+            sub_elapsed = _migrate_proc_observations(
+                cur, conn, buffer, submission_id, referencetrack_included
             )
-            e_time = time.perf_counter()
-            sub_elapsed = round(e_time - s_time, 2)
-            logger.info(
-                "Built Pandas DF from %s records. Time elapsed: %s second(s)",
-                len_proc_obs,
-                sub_elapsed,
-            )
-            logger.debug("DF Info: %s", df.info)
-            logger.debug("DF Memory Usage: %s", df.memory_usage(True))
-
-            # save dataframe to StringIO memory buffer
-            s_time = time.perf_counter()
-            buffer = StringIO()
-            df.to_csv(buffer, header=False, index=False)
-            buffer.seek(0)
-            e_time = time.perf_counter()
-            sub_elapsed = round(e_time - s_time, 2)
-            logger.info(
-                "Copied Pandas DF to StringIO memory buffer. Time elapsed: %s second(s)",
-                sub_elapsed,
-            )
-
-            # copy buffer to db
-            s_time = time.perf_counter()
-            logger.info(
-                "Copying memory buffer to 'proc_observations' and executing data migration."
-            )
-            try:
-                cur.copy_from(buffer, "proc_observations", sep=",")
-                ref = bool(referencetrack_included)
-                logger.debug(
-                    "Executing sp_execute_data_migration(%s, %s);",
-                    int(submission_id),
-                    ref,
-                )
-                cur.execute(
-                    "CALL sp_execute_data_migration(%s, %s);", (int(submission_id), ref)
-                )
-            except (Exception, psycopg2.DatabaseError) as error:
-                logger.error("Error: %s", error)
-                conn.rollback()
+            if sub_elapsed is False:
                 return 1
-            e_time = time.perf_counter()
-            sub_elapsed = round(e_time - s_time, 2)
             logger.info(
                 "Successful migration of %s 'proc_observations'. Elapsed time: %s second(s).",
                 len_proc_obs,

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -15,7 +15,7 @@ def post_msg(msg):
         client.chat_postMessage(
             channel="metadata_ops", text="<!channel> :warning: " + msg
         )
-    except SlackApiError as e:
-        logger.error(e)
-    except Exception as e:
-        logger.exception("Something went wrong while posting to slack", e)
+    except SlackApiError:
+        logger.exception("Slack API error while posting message")
+    except Exception:
+        logger.exception("Something went wrong while posting to slack")


### PR DESCRIPTION
## Summary
- Restrict CORS via `TAGBASE_CORS_ORIGINS` (no open allow-all by default) to clear python:S5122
- Harden ingest temp I/O, replace `pytz` with `timezone.utc`, tidy controllers/models/logging, and extract eTUFF helpers for cognitive complexity
- Closes the SonarCloud cleanup program from #356 (#357–#363)

## Test plan
- [x] Local pytest (incl. new `test_sonar_cleanup.py`) green; pre-commit diff-cover ≥80%
- [ ] CI tox matrix green
- [ ] SonarCloud on main: vulnerabilities=0, security rating A, code smells cleared, `/tmp` hotspots gone


Made with [Cursor](https://cursor.com)