### PR TITLE
fix: remove last Sonar commented-code smell

### DIFF
--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -28,7 +28,6 @@ def process_global_attributes_metadata(
         line = line.strip()
         logger.debug("Processing global attribute: %s", line)
         tokens = line[1:].split(" = ")
-        # attribute_name = tokens[0], attribute_value = tokens[1]
         if len(tokens) > 1:
             attributes_map[tokens[0]] = tokens[1]
         else:


### PR DESCRIPTION
## Summary
- Clears the remaining python:S125 code smell left after #364

## Test plan
- [x] Pre-commit / coverage on touched lines
- [ ] CI green; SonarCloud code_smells=0 on main


Made with [Cursor](https://cursor.com)