### PR TITLE
fix: restore ingest schema init and metadata seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,7 @@ tagbase_server/tagbase_server/coverage.xml
 services/postgis/lockfiles
 postgis-data
 dbbackups
-staging_data
+staging_data*
 
 .scratch*
 docs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,11 +141,16 @@ services:
     expose:
       - ${POSTGRES_PORT:-5432}
     healthcheck:
-      test: "PGPASSWORD=${POSTGRES_PASSWORD:-tagbase} pg_isready -d tagbase -h postgis -U tagbase"
+      # Require tagbase schema (not just pg_isready) so dependents wait for 01-tagbase.sql.
+      test: >-
+        PGPASSWORD=${POSTGRES_PASSWORD:-tagbase}
+        psql -d tagbase -h localhost -U tagbase -tAc
+        "SELECT to_regclass('public.submission')"
+        | grep -q submission
       interval: 15s
       timeout: 5s
-      retries: 5
-      start_period: 15s
+      retries: 10
+      start_period: 30s
     hostname: postgis
     image: kartoza/postgis:15-3.3
     platform: linux/amd64
@@ -163,7 +168,9 @@ services:
       # Tables-only SQL: kartoza already creates role/DB; full tagbase_schema.sql
       # aborts on CREATE ROLE/DATABASE and never creates submission/etc.
       - ./services/postgis/tagbase_schema_tables.sql:/docker-entrypoint-initdb.d/01-tagbase.sql
-      - ./services/postgis/lockfiles:/opt/data/
+      # Anonymous volume: host-mounted lockfiles survive postgis-data wipes and cause
+      # kartoza to skip init scripts (stale .entry_point.lock → no submission table).
+      - postgis-lockfiles:/opt/data/
   slack_docker:
     environment:
       - webhook=${webhook:-}
@@ -314,6 +321,7 @@ networks:
   internal-network:
 
 volumes:
+  postgis-lockfiles:
   alloy-data:
   prometheus-data:
   loki-data:

--- a/services/docker-cron/Dockerfile
+++ b/services/docker-cron/Dockerfile
@@ -2,8 +2,6 @@ FROM python:3.14-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-ARG POSTGRES_PASSWORD
-ARG POSTGRES_PORT
 
 WORKDIR /usr/src/app
 
@@ -26,9 +24,9 @@ COPY --chown=tagbase:tagbase . .
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install -r requirements.txt --no-cache-dir
 
-RUN touch .env \
-    && echo "export POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" >> /usr/src/app/.env \
-    && echo "export POSTGRES_PORT=${POSTGRES_PORT}" >> /usr/src/app/.env
+# Credentials are written at container start from runtime env (see entrypoint.sh).
+# Do not bake POSTGRES_* from build ARGs — unset ARGs produce empty exports that
+# wipe compose-provided passwords when cron sources .env.
 
 RUN chmod 777 -R /usr/src/app
 

--- a/services/docker-cron/entrypoint.sh
+++ b/services/docker-cron/entrypoint.sh
@@ -1,4 +1,26 @@
 #!/bin/sh
+set -eu
+
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-tagbase}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+
+# Runtime credentials for cron jobs (compose environment, not build ARGs).
+cat > /usr/src/app/.env <<EOF
+export POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+export POSTGRES_PORT=${POSTGRES_PORT}
+EOF
+
+echo "Seeding metadata_types and observation_types..."
+i=0
+until /usr/local/bin/python3 /usr/src/app/poll_metadata_and_obs_types.py; do
+  i=$((i + 1))
+  if [ "$i" -ge 30 ]; then
+    echo "Initial seed failed after ${i} attempts; continuing with cron"
+    break
+  fi
+  echo "Seed attempt ${i} failed; retrying in 5s..."
+  sleep 5
+done
 
 echo "Starting cron..."
 cron

--- a/services/docker-cron/poll_metadata_and_obs_types.py
+++ b/services/docker-cron/poll_metadata_and_obs_types.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 import configparser
 import os
+import sys
+
 import pandas as pd
 import psycopg2
-import requests
 
 from io import StringIO
 
@@ -68,7 +69,7 @@ def pull_resource(connection=None, key=None, param=None):
                 connection.commit()
             except (Exception, psycopg2.DatabaseError) as error:
                 print("Error writing data to table:", param, error)
-                conn.rollback()
+                connection.rollback()
                 return 1
             print("Successfully updated table:", param)
 
@@ -79,16 +80,16 @@ def connect():
     :rtype: connection
     """
     try:
-        conn = psycopg2.connect(
+        return psycopg2.connect(
             dbname="tagbase",
             user="tagbase",
             host="postgis",
-            port=os.getenv("POSTGRES_PORT"),
-            password=os.getenv("POSTGRES_PASSWORD"),
+            port=os.getenv("POSTGRES_PORT", "5432"),
+            password=os.getenv("POSTGRES_PASSWORD", "tagbase"),
         )
     except psycopg2.OperationalError as poe:
         print("Error connecting to DB: ", poe)
-    return conn
+        sys.exit(1)
 
 
 def get_metadata(connection):

--- a/tagbase_server/gunicorn.conf.py
+++ b/tagbase_server/gunicorn.conf.py
@@ -19,6 +19,17 @@ workers = max(2, multiprocessing.cpu_count())
 def post_fork(server, worker):
     from tagbase_server.__main__ import app
     from tagbase_server.telemetry import setup_telemetry
+    from tagbase_server.utils.db_utils import assert_schema_ready, connect
 
     setup_telemetry(flask_app=app.app)
     server.log.info("OpenTelemetry setup complete in worker pid=%s", worker.pid)
+
+    conn = connect()
+    if hasattr(conn, "cursor"):
+        assert_schema_ready(conn)
+        conn.close()
+        server.log.info("Tagbase schema readiness OK in worker pid=%s", worker.pid)
+    else:
+        server.log.error(
+            "Tagbase DB connect failed during worker startup pid=%s", worker.pid
+        )

--- a/tagbase_server/tagbase_server/test/test_slack_and_schema.py
+++ b/tagbase_server/tagbase_server/test/test_slack_and_schema.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+
+import importlib
+from unittest import mock
+
+import pytest
+
+from tagbase_server.utils import db_utils
+from tagbase_server.utils import slack_utils as slack_utils_mod
+
+
+def _reload_slack_utils():
+    """Undo conftest mute_slack Mock and pick up a fresh module."""
+    return importlib.reload(slack_utils_mod)
+
+
+def test_post_msg_skips_when_token_missing(monkeypatch):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    su = _reload_slack_utils()
+    with mock.patch.object(su, "WebClient") as mock_web_client:
+        su.post_msg("hello")
+        mock_web_client.assert_not_called()
+
+
+def test_post_msg_skips_when_token_not_bot(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxp-not-a-bot")
+    su = _reload_slack_utils()
+    with mock.patch.object(su, "WebClient") as mock_web_client:
+        su.post_msg("hello")
+        mock_web_client.assert_not_called()
+
+
+def test_post_msg_posts_with_bot_token(monkeypatch):
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-valid-token")
+    su = _reload_slack_utils()
+    with mock.patch.object(su, "WebClient") as mock_web_client:
+        client = mock_web_client.return_value
+        su.post_msg("hello")
+        mock_web_client.assert_called_once_with(token="xoxb-valid-token")
+        client.chat_postMessage.assert_called_once()
+        _args, kwargs = client.chat_postMessage.call_args
+        assert kwargs["channel"] == "metadata_ops"
+        assert "hello" in kwargs["text"]
+
+
+def test_post_msg_handles_slack_api_and_generic_errors(monkeypatch):
+    from slack_sdk.errors import SlackApiError
+
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-valid-token")
+    su = _reload_slack_utils()
+    client = mock.Mock()
+    with mock.patch.object(su, "WebClient", return_value=client):
+        client.chat_postMessage.side_effect = SlackApiError(
+            "fail", response=mock.Mock()
+        )
+        su.post_msg("api-fail")
+        client.chat_postMessage.side_effect = RuntimeError("boom")
+        su.post_msg("generic-fail")
+
+
+def test_connect_reraises_when_schema_missing(monkeypatch):
+    db_utils._SCHEMA_READY = False
+    fake_conn = mock.Mock()
+    cur = mock.Mock()
+    cur.fetchone.return_value = (None,)
+    fake_conn.cursor.return_value.__enter__ = mock.Mock(return_value=cur)
+    fake_conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+
+    monkeypatch.setattr(db_utils.psycopg2, "connect", mock.Mock(return_value=fake_conn))
+    monkeypatch.setattr(db_utils, "record_db_error", mock.Mock())
+
+    with pytest.raises(RuntimeError, match="submission"):
+        db_utils.connect()
+    db_utils.record_db_error.assert_called_with("schema")
+
+
+def test_assert_schema_ready_raises_when_missing():
+    db_utils._SCHEMA_READY = False
+    cur = mock.Mock()
+    cur.fetchone.return_value = (None,)
+    conn = mock.Mock()
+    conn.cursor.return_value.__enter__ = mock.Mock(return_value=cur)
+    conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+
+    with pytest.raises(RuntimeError, match="submission"):
+        db_utils.assert_schema_ready(conn)
+    assert db_utils._SCHEMA_READY is False
+
+
+def test_assert_schema_ready_caches_success():
+    db_utils._SCHEMA_READY = False
+    cur = mock.Mock()
+    cur.fetchone.return_value = ("submission",)
+    conn = mock.Mock()
+    conn.cursor.return_value.__enter__ = mock.Mock(return_value=cur)
+    conn.cursor.return_value.__exit__ = mock.Mock(return_value=False)
+
+    db_utils.assert_schema_ready(conn)
+    assert db_utils._SCHEMA_READY is True
+    db_utils.assert_schema_ready(conn)
+    assert conn.cursor.call_count == 1

--- a/tagbase_server/tagbase_server/test/test_slack_and_schema.py
+++ b/tagbase_server/tagbase_server/test/test_slack_and_schema.py
@@ -97,5 +97,7 @@ def test_assert_schema_ready_caches_success():
 
     db_utils.assert_schema_ready(conn)
     assert db_utils._SCHEMA_READY is True
+    conn.rollback.assert_called_once()
     db_utils.assert_schema_ready(conn)
     assert conn.cursor.call_count == 1
+    assert conn.rollback.call_count == 1

--- a/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
+++ b/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
@@ -220,6 +220,25 @@ def test_build_proc_observations(mock_post):
     mock_post.assert_called_once()
 
 
+@mock.patch("tagbase_server.utils.processing_utils.post_msg")
+def test_build_proc_observations_skips_short_and_comment_lines(mock_post):
+    """Non-observation lines must not raise IndexError (verify-drop style fixtures)."""
+    cur = mock.Mock()
+    conn = mock.Mock()
+    cur.fetchone.return_value = (7,)
+    content = [
+        "",
+        "# verify 1784506712",
+        "2012-03-16 18:31:39,2,22.2,longitude,degree",
+        "only,two",
+        "   ",
+    ]
+    proc_obs, count = pu._build_proc_observations(cur, conn, content, "f.txt", 1, 2)
+    assert count == 1
+    assert len(proc_obs) == 1
+    mock_post.assert_not_called()
+
+
 def test_dataframe_to_buffer_and_migrate():
     proc_obs = [[timezone.utc, 1, "1.0", 2, 3]]
     buffer = pu._dataframe_to_buffer(proc_obs, 1)
@@ -381,14 +400,16 @@ def test_base_model_ne_and_to_dict_branches():
     assert not (a != a)
 
 
-def test_slack_utils_exception_paths():
-    with mock.patch.object(
-        slack_utils.client,
-        "chat_postMessage",
-        side_effect=SlackApiError("fail", response=mock.Mock()),
-    ):
-        slack_utils.post_msg("hi")
-    with mock.patch.object(
-        slack_utils.client, "chat_postMessage", side_effect=RuntimeError("boom")
-    ):
-        slack_utils.post_msg("hi")
+def test_slack_utils_exception_paths(monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+    su = importlib.reload(slack_utils)
+    client = mock.Mock()
+    with mock.patch.object(su, "WebClient", return_value=client):
+        client.chat_postMessage.side_effect = SlackApiError(
+            "fail", response=mock.Mock()
+        )
+        su.post_msg("hi")
+        client.chat_postMessage.side_effect = RuntimeError("boom")
+        su.post_msg("hi")

--- a/tagbase_server/tagbase_server/utils/db_utils.py
+++ b/tagbase_server/tagbase_server/utils/db_utils.py
@@ -7,6 +7,29 @@ from tagbase_server.telemetry import record_db_error
 
 logger = logging.getLogger(__name__)
 
+_SCHEMA_READY = False
+
+
+def assert_schema_ready(conn):
+    """Fail fast with a clear message when tagbase tables were never initialized.
+
+    Common cause: kartoza skipped /docker-entrypoint-initdb.d after a stale
+    SCRIPTS_LOCKFILE_DIR lock while postgis-data was recreated.
+    """
+    global _SCHEMA_READY
+    if _SCHEMA_READY:
+        return
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass('public.submission')")
+        if cur.fetchone()[0] is None:
+            raise RuntimeError(
+                "Tagbase schema is missing (relation 'submission' does not exist). "
+                "Ensure services/postgis/tagbase_schema_tables.sql ran on init "
+                "(reset postgis-data and clear SCRIPTS_LOCKFILE_DIR / postgis-lockfiles "
+                "so kartoza does not skip init scripts)."
+            )
+    _SCHEMA_READY = True
+
 
 def connect():
     """
@@ -37,5 +60,11 @@ def connect():
                 "trace": poe,
             }
         )
+    try:
+        assert_schema_ready(conn)
+    except RuntimeError:
+        record_db_error("schema")
+        logger.exception("Tagbase schema readiness check failed")
+        raise
     logger.debug("Successfully connected to TagbaseDB.")
     return conn

--- a/tagbase_server/tagbase_server/utils/db_utils.py
+++ b/tagbase_server/tagbase_server/utils/db_utils.py
@@ -28,6 +28,8 @@ def assert_schema_ready(conn):
                 "(reset postgis-data and clear SCRIPTS_LOCKFILE_DIR / postgis-lockfiles "
                 "so kartoza does not skip init scripts)."
             )
+    # End the implicit transaction so callers can still set conn.autocommit.
+    conn.rollback()
     _SCHEMA_READY = True
 
 

--- a/tagbase_server/tagbase_server/utils/slack_utils.py
+++ b/tagbase_server/tagbase_server/utils/slack_utils.py
@@ -4,15 +4,25 @@ import os
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-slack_token = os.environ.get("SLACK_BOT_TOKEN", "")
-client = WebClient(token=slack_token)
 logger = logging.getLogger(__name__)
+
+
+def _slack_token():
+    return os.environ.get("SLACK_BOT_TOKEN", "").strip()
+
+
+def _slack_client(token=None):
+    return WebClient(token=token if token is not None else _slack_token())
 
 
 def post_msg(msg):
     logger.warning(msg)
+    token = _slack_token()
+    # Slack bot tokens are typically xoxb-...; anything else just spams errors.
+    if not token.startswith("xoxb-"):
+        return
     try:
-        client.chat_postMessage(
+        _slack_client(token).chat_postMessage(
             channel="metadata_ops", text="<!channel> :warning: " + msg
         )
     except SlackApiError:


### PR DESCRIPTION
## Summary
- Make PostGIS schema init reliable: anonymous `postgis-lockfiles` volume (avoids stale `.entry_point.lock` skipping `01-tagbase.sql`), healthcheck requires `submission`, and tagbase_server fails fast when the schema is missing.
- Fix docker-cron seeding: write Postgres creds from runtime env at entrypoint (stop baking empty build ARGs), harden `connect()`/`rollback()`, and seed `metadata_types` / `observation_types` once on startup.
- Skip Slack `chat.postMessage` unless `SLACK_BOT_TOKEN` starts with `xoxb-`; add regression coverage for short/non-observation eTUFF lines and schema/Slack guards.
- Ignore `staging_data*` in `.gitignore` so local backup drop folders stay untracked.

## Test plan
- [ ] Unit: `pytest tagbase_server/test/test_slack_and_schema.py tagbase_server/test/test_sonar_cleanup.py::test_build_proc_observations_skips_short_and_comment_lines`
- [ ] Fresh stack: `docker compose up -d --build postgis docker-cron tagbase_server` (no host-mounted lockfiles)
- [ ] Confirm PostGIS healthy and `\dt` includes `submission` / `metadata_types`
- [ ] Confirm docker-cron logs "Successfully updated table: metadata_types" and `SELECT count(*) FROM metadata_types` > 0
- [ ] POST a small eTUFF (e.g. verify-drop fixture) to `/ingest` → 200; metadata rows for `instrument_name` / `ptt` / `platform`
- [ ] Confirm no new `Unable to locate attribute_names`, `SlackApiError: not_authed`, or `relation "submission" does not exist` in logs