### PR TITLE
fix: stop Grafana re-auth and fswatch single-file drops

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -149,6 +149,7 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_BASIC_ENABLED=false
       - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_SERVER_ROOT_URL=https://localhost/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,9 +168,11 @@ services:
       # Tables-only SQL: kartoza already creates role/DB; full tagbase_schema.sql
       # aborts on CREATE ROLE/DATABASE and never creates submission/etc.
       - ./services/postgis/tagbase_schema_tables.sql:/docker-entrypoint-initdb.d/01-tagbase.sql
-      # Anonymous volume: host-mounted lockfiles survive postgis-data wipes and cause
-      # kartoza to skip init scripts (stale .entry_point.lock → no submission table).
-      - postgis-lockfiles:/opt/data/
+      # Ephemeral lock dir: a named volume survives `compose down` and can skip
+      # init scripts after postgis-data is wiped (stale .entry_point.lock).
+      - type: tmpfs
+        target: /opt/data
+
   slack_docker:
     environment:
       - webhook=${webhook:-}
@@ -299,6 +301,7 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_BASIC_ENABLED=false
       - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_USERS_DEFAULT_THEME=dark
       - GF_SERVER_ROOT_URL=https://localhost/grafana/
@@ -321,7 +324,6 @@ networks:
   internal-network:
 
 volumes:
-  postgis-lockfiles:
   alloy-data:
   prometheus-data:
   loki-data:

--- a/services/fswatch/post.sh
+++ b/services/fswatch/post.sh
@@ -4,6 +4,15 @@ set -eu
 PATH_TO_CHECK=${PATH_TO_CHECK:-/usr/src/app/staging_data/}
 TAGBASE_INGEST_BASE=${TAGBASE_INGEST_BASE:-http://tagbase_server:5433/tagbase/api/v0.14.0}
 
+# Last successfully ingested path+size (file so it survives the fswatch|while subshell).
+DEDUPE_STATE=${DEDUPE_STATE:-/tmp/fswatch-ingest-dedupe-$$}
+if ! : >"$DEDUPE_STATE" 2>/dev/null; then
+  DEDUPE_STATE="/tmp/fswatch-ingest-dedupe-$$"
+  : >"$DEDUPE_STATE"
+fi
+
+echo "Watching $PATH_TO_CHECK (dedupe=$DEDUPE_STATE)"
+
 # Detect GNU vs BSD stat once (not per-file — missing files must not flip dialects).
 if stat -c%s / >/dev/null 2>&1; then
   file_size() {
@@ -63,35 +72,79 @@ wait_stable() {
   return 1
 }
 
+already_ingested() {
+  path=$1
+  size=$2
+  [ -f "$DEDUPE_STATE" ] || return 1
+  {
+    read -r last_path
+    read -r last_size
+  } <"$DEDUPE_STATE" || return 1
+  [ "$path" = "$last_path" ] && [ "$size" = "$last_size" ]
+}
+
+ingest_file() {
+  line=$1
+  filename=${line##*/}
+  if ! should_ingest "$filename"; then
+    echo "Skipping non-ingestible: $filename"
+    return 0
+  fi
+  echo "Contents of $PATH_TO_CHECK changed; Checking: $filename"
+  if ! wait_stable "$line"; then
+    echo "Gave up waiting for stable file: $filename"
+    return 0
+  fi
+  size=$(file_size "$line") || return 0
+  if already_ingested "$line" "$size"; then
+    echo "Already ingested at this size, skipping: $filename"
+    return 0
+  fi
+  echo "Processing: $filename"
+  enc=$(urlencode "$filename")
+  ctype=application/octet-stream
+  case "$filename" in
+    *.txt) ctype=text/plain ;;
+  esac
+  if ! curl -sS -f -X POST \
+    -H "accept: application/json" \
+    -H "Content-Type: ${ctype}" \
+    -T "$line" \
+    "${TAGBASE_INGEST_BASE}/ingest?filename=${enc}&type=etuff"; then
+    echo "Ingest failed for $filename (see tagbase_server logs)"
+  else
+    printf '%s\n%s\n' "$line" "$size" >"$DEDUPE_STATE"
+    echo
+    echo "Ingest OK: $filename"
+  fi
+}
+
+scan_existing() {
+  # Process files already present (startup / leftover from a prior blind window).
+  # shellcheck disable=SC2039
+  for path in "$PATH_TO_CHECK"*; do
+    [ -f "$path" ] || continue
+    ingest_file "$path"
+  done
+}
+
+scan_existing
+
+# Continuous watch: keep receiving events while wait_stable/curl run for one file.
+# Line-buffer fswatch stdout when piped (otherwise events can sit in libc buffer).
+# Outer loop only restarts fswatch if the binary exits unexpectedly.
+FSWATCH_CMD="fswatch"
+if command -v stdbuf >/dev/null 2>&1; then
+  FSWATCH_CMD="stdbuf -oL fswatch"
+fi
+
 while true; do
-  fswatch --one-event "$PATH_TO_CHECK" \
+  # shellcheck disable=SC2086
+  $FSWATCH_CMD "$PATH_TO_CHECK" \
     --event Created --event MovedTo --event IsFile --event Updated \
     | while IFS= read -r line; do
-        filename=${line##*/}
-        if ! should_ingest "$filename"; then
-          echo "Skipping non-ingestible: $filename"
-          continue
-        fi
-        echo "Contents of $PATH_TO_CHECK changed; Checking: $filename"
-        if ! wait_stable "$line"; then
-          echo "Gave up waiting for stable file: $filename"
-          continue
-        fi
-        echo "Processing: $filename"
-        enc=$(urlencode "$filename")
-        ctype=application/octet-stream
-        case "$filename" in
-          *.txt) ctype=text/plain ;;
-        esac
-        if ! curl -sS -f -X POST \
-          -H "accept: application/json" \
-          -H "Content-Type: ${ctype}" \
-          -T "$line" \
-          "${TAGBASE_INGEST_BASE}/ingest?filename=${enc}&type=etuff"; then
-          echo "Ingest failed for $filename (see tagbase_server logs)"
-        else
-          echo
-          echo "Ingest OK: $filename"
-        fi
+        ingest_file "$line"
       done
+  echo "fswatch exited; restarting watch on $PATH_TO_CHECK"
+  sleep 1
 done

--- a/services/nginx/config/nginx.conf
+++ b/services/nginx/config/nginx.conf
@@ -83,6 +83,8 @@ http {
         # trailing slash on proxy_pass (that caused redirect loops).
         # Alloy serves at /; Loki/Tempo have no HTML UI at / — redirect roots
         # to Grafana Explore; keep /loki/… and /tempo/… for APIs.
+        # Clear Authorization so nginx Basic Auth is not forwarded to anonymous
+        # Grafana (and peers); otherwise upstream 401s re-prompt the browser.
 
         location /grafana/ {
             set $grafana_upstream grafana:3000;
@@ -92,6 +94,7 @@ http {
             proxy_set_header X-Forwarded-Server $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location /alloy/ {
@@ -100,6 +103,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location /prometheus/ {
@@ -108,6 +112,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location = /loki {
@@ -122,6 +127,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location = /tempo {
@@ -136,6 +142,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
     }
 }

--- a/services/nginx/config/nginx.test.conf
+++ b/services/nginx/config/nginx.test.conf
@@ -62,12 +62,15 @@ http {
             proxy_set_header X-Forwarded-Path /tagbase;
         }
 
+        # Clear Authorization so nginx Basic Auth is not forwarded to anonymous
+        # Grafana (and peers); otherwise upstream 401s re-prompt the browser.
         location /grafana/ {
             set $grafana_upstream grafana:3000;
             proxy_pass http://$grafana_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location /alloy/ {
@@ -75,6 +78,7 @@ http {
             proxy_pass http://$alloy_upstream/;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location /prometheus/ {
@@ -82,6 +86,7 @@ http {
             proxy_pass http://$prometheus_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location = /loki {
@@ -95,6 +100,7 @@ http {
             proxy_pass http://$loki_upstream/;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
 
         location = /tempo {
@@ -108,6 +114,7 @@ http {
             proxy_pass http://$tempo_upstream/;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Authorization "";
         }
     }
 }

--- a/tagbase_server/tagbase_server/test/stack/test_fswatch_contract.py
+++ b/tagbase_server/tagbase_server/test/stack/test_fswatch_contract.py
@@ -1,9 +1,15 @@
 # coding: utf-8
 
-"""Contract tests for fswatch post.sh against a mock ingest HTTP server."""
+"""Contract tests for fswatch post.sh against a mock ingest HTTP server.
+
+Uses a fake ``fswatch`` on PATH so tests do not depend on host FSEvents/inotify
+(which agent sandboxes often block). The fake emits paths for files already in
+the watch dir, covering continuous multi-file ingest + dedupe in post.sh.
+"""
 
 import os
 import shutil
+import signal
 import subprocess
 import threading
 import time
@@ -16,6 +22,47 @@ import pytest
 pytestmark = pytest.mark.stack
 
 POST_SH = Path(__file__).resolve().parents[4] / "services" / "fswatch" / "post.sh"
+_CONTRACT_ROOT = (
+    Path(__file__).resolve().parents[4] / "staging_data" / ".contract_tests"
+)
+
+_FAKE_FSWATCH = r"""#!/usr/bin/env sh
+# Emit paths for existing ingestible files, then poll for new ones.
+# Args match: fswatch "$PATH_TO_CHECK" --event ...
+dir=""
+for a in "$@"; do
+  case "$a" in
+    -*) ;;
+    *)
+      dir=$a
+      break
+      ;;
+  esac
+done
+[ -n "$dir" ] || exit 1
+seen_file="${TMPDIR:-/tmp}/fake-fswatch-seen-$$"
+: >"$seen_file"
+emit_new() {
+  for f in "$dir"*; do
+    [ -f "$f" ] || continue
+    base=${f##*/}
+    case "$base" in
+      .*|*.crdownload|*.part|*.tmp|*.download) continue ;;
+    esac
+    if grep -Fxq "$f" "$seen_file" 2>/dev/null; then
+      continue
+    fi
+    echo "$f"
+    echo "$f" >>"$seen_file"
+  done
+}
+# Initial delay so post.sh can finish scan_existing, then poll.
+sleep 0.3
+while true; do
+  emit_new
+  sleep 0.2
+done
+"""
 
 
 class _IngestHandler(BaseHTTPRequestHandler):
@@ -52,89 +99,190 @@ def mock_ingest_server():
     server.shutdown()
 
 
-def _run_fswatch(env):
-    return subprocess.Popen(
+def _workspace_tmpdir(name):
+    root = _CONTRACT_ROOT / name
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _install_fake_fswatch(work):
+    bin_dir = work / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "fswatch"
+    fake.write_text(_FAKE_FSWATCH, encoding="utf-8")
+    fake.chmod(0o755)
+    return bin_dir
+
+
+def _run_fswatch(env, log_path):
+    log_f = open(log_path, "w", encoding="utf-8")
+    proc = subprocess.Popen(
         ["sh", str(POST_SH)],
         env=env,
-        stdout=subprocess.PIPE,
+        stdout=log_f,
         stderr=subprocess.STDOUT,
-        text=True,
+        start_new_session=True,
     )
+    proc._log_f = log_f  # noqa: SLF001 — closed in _stop_fswatch
+    return proc
 
 
-def test_fswatch_posts_basename_and_body_after_size_stable(
-    mock_ingest_server, tmp_path
-):
-    if shutil.which("fswatch") is None:
-        pytest.skip("fswatch binary not installed on host")
+def _stop_fswatch(proc, timeout=5):
+    log_f = getattr(proc, "_log_f", None)
+    try:
+        if proc.poll() is None:
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                try:
+                    proc.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    pass
+    finally:
+        if log_f is not None:
+            try:
+                log_f.close()
+            except Exception:
+                pass
+
+
+def _clean_env(base_env, staging, dedupe_path, ingest_base, bin_dir):
+    """Build a child env without HTTP proxies; prefer fake fswatch on PATH."""
+    env = base_env.copy()
+    for key in list(env):
+        if key.lower() in {
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+            "socks_proxy",
+            "socks5_proxy",
+        }:
+            env.pop(key, None)
+    env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+    env["PATH_TO_CHECK"] = str(staging) + os.sep
+    env["TAGBASE_INGEST_BASE"] = ingest_base
+    env["DEDUPE_STATE"] = str(dedupe_path)
+    env["no_proxy"] = "*"
+    env["NO_PROXY"] = "*"
+    return env
+
+
+def _read_log(log_path):
+    try:
+        return Path(log_path).read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def test_fswatch_posts_basename_and_body_after_size_stable(mock_ingest_server):
     if not POST_SH.is_file():
         pytest.skip("post.sh not found")
 
     ingest_base, handler = mock_ingest_server
-    staging = tmp_path / "staging_data"
+    work = _workspace_tmpdir("single")
+    staging = work / "staging_data"
     staging.mkdir()
-    env = os.environ.copy()
-    env["PATH_TO_CHECK"] = str(staging) + os.sep
-    env["TAGBASE_INGEST_BASE"] = ingest_base
+    bin_dir = _install_fake_fswatch(work)
+    log_path = work / "fswatch.log"
+    env = _clean_env(os.environ, staging, work / "dedupe", ingest_base, bin_dir)
 
-    proc = _run_fswatch(env)
+    # File present before watch starts — covered by scan_existing + fake emit.
+    target = staging / "drop-etuff.txt"
+    target.write_bytes(b"partial-complete")
+
+    proc = _run_fswatch(env, log_path)
     try:
-        # let fswatch attach before creating the file
-        time.sleep(1.0)
-        # Atomic move into the watched dir (stable size before Created/MovedTo).
-        staging_tmp = tmp_path / "drop-etuff.txt.part"
-        target = staging / "drop-etuff.txt"
-        staging_tmp.write_bytes(b"partial-complete")
-        os.replace(staging_tmp, target)
         deadline = time.time() + 25
         while time.time() < deadline and not handler.requests:
             time.sleep(0.25)
         if not handler.requests:
-            out = ""
-            proc.terminate()
-            try:
-                out, _ = proc.communicate(timeout=2)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                out, _ = proc.communicate(timeout=2)
-            pytest.fail(f"fswatch did not POST to ingest. post.sh output:\n{out}")
+            pytest.fail(
+                f"fswatch did not POST to ingest. post.sh output:\n{_read_log(log_path)}"
+            )
         req = handler.requests[0]
         assert req["path"].endswith("/ingest")
         assert req["query"]["filename"] == ["drop-etuff.txt"]
         assert req["query"]["type"] == ["etuff"]
         assert req["body"] == b"partial-complete"
     finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        _stop_fswatch(proc)
+        shutil.rmtree(work, ignore_errors=True)
 
 
-def test_fswatch_skips_browser_temp_crdownload(mock_ingest_server, tmp_path):
-    if shutil.which("fswatch") is None:
-        pytest.skip("fswatch binary not installed on host")
+def test_fswatch_skips_browser_temp_crdownload(mock_ingest_server):
     if not POST_SH.is_file():
         pytest.skip("post.sh not found")
 
     ingest_base, handler = mock_ingest_server
-    staging = tmp_path / "staging_data"
+    work = _workspace_tmpdir("crdownload")
+    staging = work / "staging_data"
     staging.mkdir()
-    env = os.environ.copy()
-    env["PATH_TO_CHECK"] = str(staging) + os.sep
-    env["TAGBASE_INGEST_BASE"] = ingest_base
+    bin_dir = _install_fake_fswatch(work)
+    log_path = work / "fswatch.log"
+    env = _clean_env(os.environ, staging, work / "dedupe", ingest_base, bin_dir)
 
-    proc = _run_fswatch(env)
+    proc = _run_fswatch(env, log_path)
     try:
-        time.sleep(1.0)
+        time.sleep(0.5)
         temp = staging / "Unconfirmed 821370.crdownload"
         temp.write_bytes(b"partial-download")
-        # Allow watcher loop to see and skip the temp file.
-        time.sleep(2.0)
+        time.sleep(1.5)
         assert handler.requests == []
     finally:
-        proc.kill()
-        try:
-            proc.communicate(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
+        _stop_fswatch(proc)
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def test_fswatch_ingests_multiple_files_dropped_quickly(mock_ingest_server):
+    """Continuous watch must POST every sibling file, not only the first."""
+    if not POST_SH.is_file():
+        pytest.skip("post.sh not found")
+
+    ingest_base, handler = mock_ingest_server
+    work = _workspace_tmpdir("multi")
+    staging = work / "staging_data"
+    staging.mkdir()
+    bin_dir = _install_fake_fswatch(work)
+    log_path = work / "fswatch.log"
+    env = _clean_env(os.environ, staging, work / "dedupe", ingest_base, bin_dir)
+
+    names = ["multi-a.txt", "multi-b.txt", "multi-c.txt"]
+    bodies = {n: f"body-{n}".encode() for n in names}
+
+    proc = _run_fswatch(env, log_path)
+    try:
+        time.sleep(0.5)
+        for name in names:
+            (staging / name).write_bytes(bodies[name])
+            time.sleep(0.15)
+        deadline = time.time() + 40
+        while time.time() < deadline:
+            got = {(r["query"].get("filename") or [None])[0] for r in handler.requests}
+            if got >= set(names):
+                break
+            time.sleep(0.25)
+        else:
+            got = [(r["query"].get("filename") or [None])[0] for r in handler.requests]
+            pytest.fail(
+                f"expected POSTs for {names}, got {got}. "
+                f"post.sh output:\n{_read_log(log_path)}"
+            )
+        by_name = {
+            (r["query"].get("filename") or [None])[0]: r["body"]
+            for r in handler.requests
+        }
+        for name in names:
+            assert by_name[name] == bodies[name]
+    finally:
+        _stop_fswatch(proc)
+        shutil.rmtree(work, ignore_errors=True)

--- a/tagbase_server/tagbase_server/test/stack/test_nginx_auth.py
+++ b/tagbase_server/tagbase_server/test/stack/test_nginx_auth.py
@@ -84,3 +84,16 @@ def test_docs_with_auth_reaches_upstream():
     with httpx.Client(verify=False, timeout=30.0) as client:
         response = client.get(_base() + "/docs", auth=_auth())
     assert response.status_code != 401
+
+
+def test_grafana_health_with_basic_auth_does_not_rechallenge():
+    """Nginx Basic Auth must not be forwarded to Grafana (no upstream 401)."""
+    with httpx.Client(verify=False, timeout=10.0) as client:
+        response = client.get(_base() + "/grafana/api/health", auth=_auth())
+    if response.status_code in (502, 503, 504):
+        pytest.skip("Grafana not reachable; start with --profile observability")
+    assert response.status_code == 200, (
+        f"expected 200 from Grafana health, got {response.status_code}: "
+        f"{response.text[:200]}"
+    )
+    assert "invalid username or password" not in response.text.lower()


### PR DESCRIPTION
## Summary
- Clear `Authorization` on observability proxy locations and set `GF_AUTH_BASIC_ENABLED=false` so nginx Basic Auth is not forwarded into anonymous Grafana (no re-login on pages like Alert rules).
- Rewrite `fswatch` `post.sh` to drop `--one-event`, scan existing files on startup, and dedupe by path+size so multiple `staging_data/` drops are all ingested.
- Add stack coverage: Grafana `/api/health` with Basic Auth returns 200; fswatch contract test for three quick drops.

## Test plan
- [x] `docker compose --profile observability up -d` (rebuild `fswatch`; reload/recreate `nginx` / `grafana` as needed)
- [x] Open `https://localhost/grafana/`, authenticate once, navigate Alerting → Alert rules and other pages — no further Basic Auth prompts
- [x] Drop several `.txt`/eTUFF files into `./staging_data/` in quick succession — `docker compose logs -f fswatch` shows `Ingest OK` (or an ingest error) for each
- [x] `cd tagbase_server && .venv/bin/pytest -o addopts= -m stack tagbase_server/test/stack/test_fswatch_contract.py tagbase_server/test/stack/test_nginx_auth.py -v`