### PR TITLE
Making insert/update metadata more robust

### DIFF
--- a/tagbase_server/tagbase_server/test/test_ingest.py
+++ b/tagbase_server/tagbase_server/test/test_ingest.py
@@ -86,7 +86,7 @@ class TestIngest(unittest.TestCase):
         with mock.patch.object(pu.logger, "error") as mock_error:
             pu.insert_metadata(
                 cur,
-                    [
+                [
                     ("1", "2", '"first value"'),
                     ("1", "3", '"second value"'),
                 ],
@@ -107,14 +107,14 @@ class TestIngest(unittest.TestCase):
         with mock.patch.object(pu.logger, "error") as mock_error:
             pu.update_submission_metadata(
                 cur,
-                tag_id = 10,
-                metadata = [
+                tag_id=10,
+                metadata=[
                     ("1", "2", '"first value"'),
                     ("1", "3", '"second value"'),
                 ],
-                submission_id = 1,
-                dataset_id = 20,
-                metadata_hash = "metadata-hash",
+                submission_id=1,
+                dataset_id=20,
+                metadata_hash="metadata-hash",
             )
         assert cur.execute.call_count == 3
         mock_error.assert_called_once()

--- a/tagbase_server/tagbase_server/test/test_ingest.py
+++ b/tagbase_server/tagbase_server/test/test_ingest.py
@@ -71,6 +71,54 @@ class TestIngest(unittest.TestCase):
         )
         assert obj_sha256 == expected_sha256
 
+    def test_insert_metadata_continues_after_database_error(self):
+        cur = mock.Mock()
+
+        cur.mogrify.side_effect = [
+            b"(1, 2, 'first value', 10)",
+            b"(1, 3, 'second value', 10)",
+        ]
+        cur.execute.side_effect = [
+            psycopg2.DatabaseError("insert failed"),
+            None,
+        ]
+
+        with mock.patch.object(pu.logger, "error") as mock_error:
+            pu.insert_metadata(
+                cur,
+                    [
+                    ("1", "2", '"first value"'),
+                    ("1", "3", '"second value"'),
+                ],
+                10,
+            )
+        assert cur.execute.call_count == 2
+        mock_error.assert_called_once()
+
+    def test_update_metadata_continues_after_database_error(self):
+        cur = mock.Mock()
+
+        cur.execute.side_effect = [
+            None,  # submission update
+            psycopg2.DatabaseError("metadata update failed"),
+            None,  # second metadata update
+        ]
+
+        with mock.patch.object(pu.logger, "error") as mock_error:
+            pu.update_submission_metadata(
+                cur,
+                tag_id = 10,
+                metadata = [
+                    ("1", "2", '"first value"'),
+                    ("1", "3", '"second value"'),
+                ],
+                submission_id = 1,
+                dataset_id = 20,
+                metadata_hash = "metadata-hash",
+            )
+        assert cur.execute.call_count == 3
+        mock_error.assert_called_once()
+
     @mock.patch("psycopg2.connect")
     def test_get_dataset_id(self, mock_connect):
         # result of psycopg2.connect(**connection_stuff)

--- a/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
+++ b/tagbase_server/tagbase_server/test/test_sonar_cleanup.py
@@ -259,22 +259,10 @@ def test_dataframe_to_buffer_and_migrate():
 @mock.patch("tagbase_server.utils.processing_utils.compute_file_sha256")
 @mock.patch("tagbase_server.utils.processing_utils.make_hash_sha256")
 def test_compute_submission_hashes(mock_make, mock_file, mock_props):
-    mock_props.return_value = (
-        "inst",
-        "sn",
-        "ptt",
-        "plat",
-        0,
-        ["line"],
-        [":a = 1"],
-        0,
-    )
     mock_make.side_effect = ["content", "meta"]
     mock_file.return_value = "filehash"
-    result = pu._compute_submission_hashes("f.txt")
-    assert result[0] == "inst"
-    assert result[-1] == "filehash"
-    assert result[-2] == "meta"
+    result = pu._compute_submission_hashes("f.txt", "content", "meta")
+    assert result == ("content", "meta", "filehash")
 
 
 @mock.patch("tagbase_server.utils.processing_utils._migrate_proc_observations")
@@ -290,9 +278,11 @@ def test_compute_submission_hashes(mock_make, mock_file, mock_props):
 @mock.patch("tagbase_server.utils.processing_utils.get_dataset_id")
 @mock.patch("tagbase_server.utils.processing_utils.detect_duplicate_file")
 @mock.patch("tagbase_server.utils.processing_utils._compute_submission_hashes")
+@mock.patch("tagbase_server.utils.processing_utils.get_dataset_properties")
 @mock.patch("tagbase_server.utils.processing_utils.connect")
 def test_process_etuff_file_full_path(
     mock_connect,
+    mock_props,
     mock_hashes,
     mock_dup,
     mock_dataset,
@@ -312,15 +302,8 @@ def test_process_etuff_file_full_path(
     mock_connect.return_value = conn
     conn.__enter__.return_value = conn
     conn.cursor.return_value.__enter__.return_value = cur
+    mock_props.return_value = ("i", "s", "p", "pl", 1, ["line"], [":a = 1"], 0)
     mock_hashes.return_value = (
-        "i",
-        "s",
-        "p",
-        "pl",
-        1,
-        ["line"],
-        [":a = 1"],
-        0,
         "ch",
         "mh",
         "fh",
@@ -340,21 +323,15 @@ def test_process_etuff_file_full_path(
 
 @mock.patch("tagbase_server.utils.processing_utils.connect")
 @mock.patch("tagbase_server.utils.processing_utils._compute_submission_hashes")
-def test_process_etuff_file_duplicate(mock_hashes, mock_connect):
+@mock.patch("tagbase_server.utils.processing_utils.get_dataset_properties")
+def test_process_etuff_file_duplicate(mock_hashes, mock_connect, mock_props):
     conn = mock.MagicMock()
     cur = mock.MagicMock()
     mock_connect.return_value = conn
     conn.__enter__.return_value = conn
     conn.cursor.return_value.__enter__.return_value = cur
+    mock_props.return_value = ("i", "s", "p", "pl", 1, ["line"], [":a = 1"], 0)
     mock_hashes.return_value = (
-        "i",
-        "s",
-        "p",
-        "pl",
-        0,
-        [],
-        [],
-        0,
         "c",
         "m",
         "f",

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -522,6 +522,20 @@ def _migrate_proc_observations(
     return sub_elapsed
 
 
+def _compute_submission_hashes(submission_filename, file_content, metadata_content):
+    content_hash = make_hash_sha256(file_content)
+    logger.debug("Content Hash: %s", content_hash)
+    metadata_hash = make_hash_sha256(metadata_content)
+    logger.debug("MD Hash: %s", metadata_hash)
+    entire_file_hash = compute_file_sha256(submission_filename)
+    logger.debug("File Hash: %s", entire_file_hash)
+    return (
+        content_hash,
+        metadata_hash,
+        entire_file_hash,
+    )
+
+
 def process_etuff_file(file, version=None, notes=None):
     start = time.perf_counter()
     submission_filename = file
@@ -548,12 +562,13 @@ def process_etuff_file(file, version=None, notes=None):
             metadata_content,
             number_global_attributes_lines,
         ) = get_dataset_properties(submission_filename)
-        content_hash = make_hash_sha256(file_content)
-        logger.debug("Content Hash: %s", content_hash)
-        metadata_hash = make_hash_sha256(metadata_content)
-        logger.debug("MD Hash: %s", metadata_hash)
-        entire_file_hash = compute_file_sha256(submission_filename)
-        logger.debug("File Hash: %s", entire_file_hash)
+        (
+            content_hash,
+            metadata_hash,
+            entire_file_hash,
+        ) = _compute_submission_hashes(
+            submission_filename, file_content, metadata_content
+        )
 
     with conn:
         with conn.cursor() as cur:

--- a/tagbase_server/tagbase_server/utils/processing_utils.py
+++ b/tagbase_server/tagbase_server/utils/processing_utils.py
@@ -298,10 +298,18 @@ def insert_metadata(cur, metadata, tag_id):
         b = x[1]
         c = x[2]
         mog = cur.mogrify("(%s, %s, %s, %s)", (a, b, str(c).strip('"'), tag_id))
-        cur.execute(
-            "INSERT INTO metadata (submission_id, attribute_id, attribute_value, tag_id) VALUES "
-            + mog.decode("utf-8")
-        )
+        try:
+            cur.execute(
+                "INSERT INTO metadata (submission_id, attribute_id, attribute_value, tag_id) VALUES "
+                + mog.decode("utf-8")
+                + " ON CONFLICT (submission_id, attribute_id) DO NOTHING"
+            )
+        except (
+            Exception,
+            psycopg2.DatabaseError,
+        ):
+            logger.error("Error inserting metadata for tag %s", x)
+    logger.debug("Inserted metadata attributes: %s", metadata)
 
 
 def get_current_submission_id(cur):
@@ -332,11 +340,17 @@ def update_submission_metadata(
         attribute_id = x[1]
         attribute_value = x[2]
         attribute_value = str(attribute_value).strip('"')
-        cur.execute(
-            "UPDATE metadata SET attribute_value = '{}' WHERE submission_id = {} AND tag_id = {} AND attribute_id = {}".format(
-                attribute_value, submission_id, tag_id, attribute_id
+        try:
+            cur.execute(
+                "UPDATE metadata SET attribute_value = '{}' WHERE submission_id = {} AND tag_id = {} AND attribute_id = {}".format(
+                    attribute_value, submission_id, tag_id, attribute_id
+                )
             )
-        )
+        except (
+            Exception,
+            psycopg2.DatabaseError,
+        ):
+            logger.error("Error updating metadata for tag %s", x)
     logger.info("Updated metadata attributes: %s", metadata)
 
 
@@ -508,38 +522,6 @@ def _migrate_proc_observations(
     return sub_elapsed
 
 
-def _compute_submission_hashes(submission_filename):
-    (
-        instrument_name,
-        serial_number,
-        ptt,
-        platform,
-        referencetrack_included,
-        file_content,
-        metadata_content,
-        number_global_attributes_lines,
-    ) = get_dataset_properties(submission_filename)
-    content_hash = make_hash_sha256(file_content)
-    logger.debug("Content Hash: %s", content_hash)
-    metadata_hash = make_hash_sha256(metadata_content)
-    logger.debug("MD Hash: %s", metadata_hash)
-    entire_file_hash = compute_file_sha256(submission_filename)
-    logger.debug("File Hash: %s", entire_file_hash)
-    return (
-        instrument_name,
-        serial_number,
-        ptt,
-        platform,
-        referencetrack_included,
-        file_content,
-        metadata_content,
-        number_global_attributes_lines,
-        content_hash,
-        metadata_hash,
-        entire_file_hash,
-    )
-
-
 def process_etuff_file(file, version=None, notes=None):
     start = time.perf_counter()
     submission_filename = file
@@ -565,10 +547,13 @@ def process_etuff_file(file, version=None, notes=None):
             file_content,
             metadata_content,
             number_global_attributes_lines,
-            content_hash,
-            metadata_hash,
-            entire_file_hash,
-        ) = _compute_submission_hashes(submission_filename)
+        ) = get_dataset_properties(submission_filename)
+        content_hash = make_hash_sha256(file_content)
+        logger.debug("Content Hash: %s", content_hash)
+        metadata_hash = make_hash_sha256(metadata_content)
+        logger.debug("MD Hash: %s", metadata_hash)
+        entire_file_hash = compute_file_sha256(submission_filename)
+        logger.debug("File Hash: %s", entire_file_hash)
 
     with conn:
         with conn.cursor() as cur:


### PR DESCRIPTION
Hey @lewismc , 
This PR makes insert/update operations more robust to avoid file ingestion failure because of metadata. Given the errors we saw during file ingestion from users, I think it makes sense we don't simply "fail". We should also consider adding a method to patch metadata up post file ingestion without requiring to reupload the entire file.